### PR TITLE
Add Codespaces preview and shared PDF downloader

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "Asian Languages preview",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:20",
+  "forwardPorts": [3000, 5000],
+  "portsAttributes": {
+    "3000": {
+      "label": "Static public preview",
+      "onAutoForward": "openPreview"
+    },
+    "5000": {
+      "label": "Firebase Hosting emulator",
+      "onAutoForward": "notify"
+    }
+  },
+  "postAttachCommand": "npm run preview"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,11 @@
 {
   "name": "Asian Languages preview",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:20",
-  "forwardPorts": [3000, 5000],
+  "forwardPorts": [
+    3000,
+    5000,
+    5001
+  ],
   "portsAttributes": {
     "3000": {
       "label": "Static public preview",
@@ -9,6 +13,10 @@
     },
     "5000": {
       "label": "Firebase Hosting emulator",
+      "onAutoForward": "notify"
+    },
+    "5001": {
+      "label": "Firebase Functions emulator",
       "onAutoForward": "notify"
     }
   },

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+asian-languages.com

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-asian-languages.com

--- a/docs/hangul.html
+++ b/docs/hangul.html
@@ -6,9 +6,9 @@
   <meta name="description" content="Download free printable handwriting practice worksheets for Korean Hangul characters. Improve your writing skills.">
   <title>Korean Hangul Writing Practice Worksheets | Asian Languages</title>
 
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" 
-        rel="stylesheet" 
-        integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" 
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+        rel="stylesheet"
+        integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
         crossorigin="anonymous">
 
   <link rel="stylesheet" href="css/style.css">
@@ -77,13 +77,14 @@
     </div>
 </footer>
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" 
-          integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" 
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+          integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
           crossorigin="anonymous"></script>
 
   <script>
     document.getElementById('current-year').textContent = new Date().getFullYear();
   </script>
+  <script src="js/pdf-utils.js"></script>
   <script src="js/hangul.js"></script>
 </body>
 </html>

--- a/docs/hanzi.html
+++ b/docs/hanzi.html
@@ -8,8 +8,8 @@
 
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
         <link rel="stylesheet" href="css/style.css">
-        
-        <script src="https://cdn.jsdelivr.net/npm/hanzi-writer@2.2.2/dist/hanzi-writer.min.js"></script>    
+
+        <script src="https://cdn.jsdelivr.net/npm/hanzi-writer@2.2.2/dist/hanzi-writer.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     </head>
@@ -34,7 +34,7 @@
         </nav>
     </div>
 </header>
-            
+
                     <main class="container my-4">
                         <section class="hanzi-introduction text-center mb-5">
                             <h2 class="display-4">Hanzi 汉字 to learn</h2>
@@ -71,7 +71,7 @@
                                                 </label>
                                                 <input type="text" id="quiz-input" class="form-control form-control-lg" placeholder="e.g., 人口木手">
                                             </div>
-                                            
+
                                             <div class="text-center">
                                                 <button id="start-quiz-btn" class="btn btn-warning btn-lg">Start Quiz</button>
                                             </div>
@@ -97,8 +97,9 @@
                                 </div>
                             </div>
                         </footer>
-            
+
             <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
-            <script src="js/hanzi.js"></script>   
+            <script src="js/pdf-utils.js"></script>
+            <script src="js/hanzi.js"></script>
         </body>
 </html>

--- a/docs/japanese.html
+++ b/docs/japanese.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Japanese - Asian Languages</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" xintegrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crosso[...]
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <!-- Incluimos tu archivo CSS para estilos personalizados -->
     <link rel="stylesheet" href="css/style.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
@@ -30,7 +30,7 @@
         </nav>
     </div>
 </header>
-                
+
     <main class="container my-4">
         <section class="japanese-introduction text-center mb-5">
             <h2 class="display-4">Japanese 日本語 to learn <span class="idioma-japones"></span></h2>
@@ -48,19 +48,19 @@
             <section class="japanese-writing-section text-center">
                 <h2 class="display-4">Japanese writing worksheet</h2>
                 <div id="japanese-writing-grid" class="japanese-writing-grid d-flex flex-wrap justify-content-center border p-3">
-                
+
                     <div id="placeholder-message" class="text-muted mt-3">Write in Japanese.</div>
                 </div>
-              
+
                 <div class="mt-3">
                     <button id="clear-all" class="btn btn-danger me-2">Clear All</button>
                     <button id="download-pdf" class="btn btn-info">Download PDF</button>
                 </div>
             </section>
-            
+
         </section>
     </main>
-  
+
     <footer class="bg-dark text-white text-center py-3">
         <div class="container">
             <p class="mb-0">&copy; <span id="current-year"></span> All rights reserved, by David.</p>
@@ -72,12 +72,13 @@
             </div>
         </div>
     </footer>
-  
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" xintegrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="an[...]
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <script>
         // Script para actualizar el año en el footer
         document.getElementById('current-year').textContent = new Date().getFullYear();
     </script>
+    <script src="js/pdf-utils.js"></script>
     <script src="js/japanese.js"></script>
 </body>
 </html>

--- a/docs/js/hangul.js
+++ b/docs/js/hangul.js
@@ -39,7 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     canvas.style.top = '0';
                     canvas.style.left = '0';
                     squareContainer.appendChild(canvas);
-                    
+
                     const charDisplay = document.createElement('div');
                     charDisplay.textContent = char;
                     charDisplay.style.fontSize = '3em';
@@ -49,7 +49,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     charDisplay.style.top = '50%';
                     charDisplay.style.left = '50%';
                     charDisplay.style.transform = 'translate(-50%, -50%)';
-                    charDisplay.style.pointerEvents = 'none'; 
+                    charDisplay.style.pointerEvents = 'none';
                     squareContainer.appendChild(charDisplay);
 
                     phraseContainer.appendChild(squareContainer);
@@ -107,7 +107,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             y: clientY - rect.top
                         };
                     };
-                    
+
                     canvas.addEventListener('mousedown', startDrawing);
                     canvas.addEventListener('mousemove', draw);
                     canvas.addEventListener('mouseup', stopDrawing);
@@ -138,7 +138,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const hangulText = event.target.value;
         generateHangulSquares(hangulText);
     });
-    
+
     clearAllButton.addEventListener('click', () => {
         canvases.forEach(canvas => {
             const ctx = canvas.getContext('2d');
@@ -147,38 +147,26 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     downloadPdfButton.addEventListener('click', async () => {
+        if (canvases.length === 0) {
+            alert('No hay caracteres para descargar. Por favor, escribe algunos en el campo de texto.');
+            return;
+        }
+
+        downloadPdfButton.textContent = 'Generando PDF...';
+        downloadPdfButton.disabled = true;
+
         try {
-            const gridElement = document.getElementById('hangul-writing-grid');
-            if (!gridElement) return;
-
-            const canvas = await html2canvas(gridElement, {
-                backgroundColor: "#ffffff"
+            await window.AsianLanguagesPdf.downloadElementAsPdf({
+                element: document.getElementById('hangul-writing-grid'),
+                filename: 'hangul-worksheet.pdf',
+                title: 'Hangul Worksheet',
             });
-
-            const imgData = canvas.toDataURL("image/png");
-
-            const { jsPDF } = window.jspdf;
-            const pdf = new jsPDF("p", "mm", "a4");
-
-            const pageWidth = pdf.internal.pageSize.getWidth();
-
-            const today = new Date().toLocaleDateString("es-ES");
-            pdf.setFont("helvetica", "bold");
-            pdf.setFontSize(16);
-            pdf.text("Hangul Worksheet", pageWidth / 2, 15, { align: "center" });
-
-            pdf.setFont("helvetica", "normal");
-            pdf.setFontSize(12);
-            pdf.text(`Fecha: ${today}`, pageWidth / 2, 23, { align: "center" });
-
-            const imgWidth = pageWidth - 20;
-            const imgHeight = (canvas.height * imgWidth) / canvas.width;
-            pdf.addImage(imgData, "PNG", 10, 30, imgWidth, imgHeight);
-
-            pdf.save("hangul-worksheet.pdf");
         } catch (error) {
             console.error("Error generando PDF:", error);
-            alert("Hubo un error al generar el PDF.");
+            alert("Hubo un error al generar el PDF. Revisa la consola para más detalles.");
+        } finally {
+            downloadPdfButton.textContent = 'Download PDF';
+            downloadPdfButton.disabled = false;
         }
     });
 

--- a/docs/js/hanzi.js
+++ b/docs/js/hanzi.js
@@ -4,43 +4,38 @@ document.addEventListener('DOMContentLoaded', () => {
     const animateAllButton = document.getElementById('animate-all');
     const downloadPdfButton = document.getElementById('download-pdf');
     const placeholderMessage = document.getElementById('placeholder-message');
- 
+
     const quizInput = document.getElementById('quiz-input');
     const startQuizBtn = document.getElementById('start-quiz-btn');
     const quizTarget = document.getElementById('quiz-target');
     const quizPlaceholder = document.getElementById('quiz-placeholder');
-    
-    const radicalColor = '#168F16'; 
-    const customStrokeWidth = 3; 
- 
+
+    const radicalColor = '#168F16';
+    const customStrokeWidth = 3;
+
     let writers = [];
     let quizWriters = [];
- 
-    // ─────────────────────────────────────────────────────────────────
-    // ▼ CAMBIA ESTA URL por la que te dé "firebase deploy" en el paso 6
-    // ─────────────────────────────────────────────────────────────────
-    const FUNCTION_URL = 'https://console.firebase.google.com/project/asian-languages/usage/details';
- 
+
     console.log("El script hanzi.js se ha cargado correctamente.");
- 
+
     const generateHanziSquares = (characters) => {
         tianZiGeGrid.innerHTML = '';
         writers.length = 0;
- 
+
         if (characters.length === 0) {
             placeholderMessage.style.display = 'block';
             return;
         } else {
             placeholderMessage.style.display = 'none';
         }
- 
+
         for (const char of characters) {
             const squareContainer = document.createElement('div');
             squareContainer.classList.add('tian-zi-ge-square', 'border', 'border-secondary', 'm-1');
             const squareId = `hanzi-square-${char}-${Date.now()}`;
             squareContainer.id = squareId;
             tianZiGeGrid.appendChild(squareContainer);
- 
+
             const writer = HanziWriter.create(squareId, char, {
                 width: 100,
                 height: 100,
@@ -54,19 +49,19 @@ document.addEventListener('DOMContentLoaded', () => {
             writers.push(writer);
         }
     };
- 
+
     const startQuiz = () => {
         const characters = quizInput.value.replace(/\s/g, '').slice(0, 10);
         quizTarget.innerHTML = '';
         quizWriters.length = 0;
- 
+
         if (characters.length === 0) {
             quizPlaceholder.style.display = 'block';
             return;
         } else {
             quizPlaceholder.style.display = 'none';
         }
- 
+
         for (let i = 0; i < characters.length; i++) {
             const char = characters[i];
             const quizContainerId = `quiz-char-${i}`;
@@ -76,7 +71,7 @@ document.addEventListener('DOMContentLoaded', () => {
             quizContainer.style.width = '150px';
             quizContainer.style.height = '150px';
             quizTarget.appendChild(quizContainer);
- 
+
             const writer = HanziWriter.create(quizContainerId, char, {
                 width: 150,
                 height: 150,
@@ -93,97 +88,34 @@ document.addEventListener('DOMContentLoaded', () => {
             quizWriters.push(writer);
         }
     };
- 
+
     hanziInput.addEventListener('input', (event) => {
         const hanziText = event.target.value.replace(/\s/g, '');
         generateHanziSquares(hanziText);
     });
- 
+
     animateAllButton.addEventListener('click', () => {
         writers.forEach(writer => writer.animateCharacter());
     });
-    
+
     startQuizBtn.addEventListener('click', () => {
       startQuiz();
     });
- 
-    // ─────────────────────────────────────────────────────────────────
-    // DESCARGA PDF — ahora usa el servidor en lugar de jsPDF/html2canvas
-    // ─────────────────────────────────────────────────────────────────
+
     downloadPdfButton.addEventListener('click', async () => {
         if (writers.length === 0) {
             alert('No hay caracteres para descargar.');
             return;
         }
- 
+
         downloadPdfButton.textContent = 'Generando PDF...';
         downloadPdfButton.disabled = true;
- 
+
         try {
-            // 1. Capturar el SVG que HanziWriter ya dibujó en el grid
-            const gridContainer = document.getElementById('tian-zi-ge-grid');
- 
-            // 2. Construir un HTML completo para que Puppeteer lo renderice
-            //    Se incluyen los SVGs tal como están pintados en pantalla
-            const htmlParaServidor = `
-                <!DOCTYPE html>
-                <html>
-                <head>
-                    <meta charset="UTF-8">
-                    <style>
-                        body {
-                            margin: 0;
-                            padding: 16px;
-                            background: #ffffff;
-                            font-family: sans-serif;
-                        }
-                        #tian-zi-ge-grid {
-                            display: flex;
-                            flex-wrap: wrap;
-                            gap: 8px;
-                        }
-                        .tian-zi-ge-square {
-                            border: 1px solid #ccc;
-                            display: inline-block;
-                        }
-                        /* Líneas guía del cuaderno tian zi ge */
-                        svg line {
-                            stroke: #ccc;
-                            stroke-width: 0.5px;
-                        }
-                    </style>
-                </head>
-                <body>
-                    <div id="tian-zi-ge-grid">
-                        ${gridContainer.innerHTML}
-                    </div>
-                </body>
-                </html>
-            `;
- 
-            // 3. Enviar al Cloud Function y esperar el PDF
-            const respuesta = await fetch(FUNCTION_URL, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    html: htmlParaServidor,
-                    filename: 'hanzi-worksheet',
-                }),
+            await window.AsianLanguagesPdf.downloadElementAsPdf({
+                element: document.getElementById('tian-zi-ge-grid'),
+                filename: 'hanzi-worksheet.pdf',
             });
- 
-            if (!respuesta.ok) {
-                throw new Error(`Error del servidor: ${respuesta.status}`);
-            }
- 
-            // 4. Descargar el PDF automáticamente
-            const blob = await respuesta.blob();
-            const url = URL.createObjectURL(blob);
-            const link = document.createElement('a');
-            link.href = url;
-            link.download = 'hanzi-worksheet.pdf';
-            link.click();
-            URL.revokeObjectURL(url);
- 
         } catch (error) {
             console.error('Error generando el PDF:', error);
             alert('Hubo un error al generar el PDF. Revisa la consola para más detalles.');
@@ -192,9 +124,9 @@ document.addEventListener('DOMContentLoaded', () => {
             downloadPdfButton.disabled = false;
         }
     });
- 
+
     generateHanziSquares('你好');
- 
+
     quizInput.value = '中文';
     startQuiz();
 });

--- a/docs/js/hanzi.js
+++ b/docs/js/hanzi.js
@@ -12,6 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const radicalColor = '#168F16';
     const customStrokeWidth = 3;
+    const maxPreviewCharacters = 60;
 
     let writers = [];
     let quizWriters = [];
@@ -25,18 +26,28 @@ document.addEventListener('DOMContentLoaded', () => {
         if (characters.length === 0) {
             placeholderMessage.style.display = 'block';
             return;
-        } else {
-            placeholderMessage.style.display = 'none';
         }
 
-        for (const char of characters) {
+        placeholderMessage.style.display = 'none';
+
+        const previewCharacters = Array.from(characters).slice(0, maxPreviewCharacters);
+        const fragment = document.createDocumentFragment();
+
+        if (characters.length > maxPreviewCharacters) {
+            const previewNotice = document.createElement('div');
+            previewNotice.classList.add('alert', 'alert-info', 'w-100', 'text-center');
+            previewNotice.textContent = `Vista previa limitada a ${maxPreviewCharacters} caracteres para evitar que la página se congele. El PDF usará todo el texto.`;
+            fragment.appendChild(previewNotice);
+        }
+
+        previewCharacters.forEach((char, index) => {
             const squareContainer = document.createElement('div');
             squareContainer.classList.add('tian-zi-ge-square', 'border', 'border-secondary', 'm-1');
-            const squareId = `hanzi-square-${char}-${Date.now()}`;
+            const squareId = `hanzi-square-${index}-${char.codePointAt(0)}`;
             squareContainer.id = squareId;
-            tianZiGeGrid.appendChild(squareContainer);
+            fragment.appendChild(squareContainer);
 
-            const writer = HanziWriter.create(squareId, char, {
+            const writer = HanziWriter.create(squareContainer, char, {
                 width: 100,
                 height: 100,
                 padding: 5,
@@ -47,7 +58,9 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             squareContainer.addEventListener('click', () => writer.animateCharacter());
             writers.push(writer);
-        }
+        });
+
+        tianZiGeGrid.appendChild(fragment);
     };
 
     const startQuiz = () => {

--- a/docs/js/hanzi.js
+++ b/docs/js/hanzi.js
@@ -112,8 +112,8 @@ document.addEventListener('DOMContentLoaded', () => {
         downloadPdfButton.disabled = true;
 
         try {
-            await window.AsianLanguagesPdf.downloadElementAsPdf({
-                element: document.getElementById('tian-zi-ge-grid'),
+            await window.AsianLanguagesPdf.downloadHanziWorksheetPdf({
+                characters: hanziInput.value.replace(/\s/g, ''),
                 filename: 'hanzi-worksheet.pdf',
             });
         } catch (error) {

--- a/docs/js/japanese.js
+++ b/docs/js/japanese.js
@@ -5,15 +5,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const downloadPdfButton = document.getElementById('download-pdf');
     const placeholderMessage = document.getElementById('placeholder-message');
 
-    const canvases = []; 
+    const canvases = [];
 
     /**
-     * 
-     * @param {string} text 
+     *
+     * @param {string} text
      */
     const generateJapaneseSquares = (text) => {
-        japaneseWritingGrid.innerHTML = ''; 
-        canvases.length = 0; 
+        japaneseWritingGrid.innerHTML = '';
+        canvases.length = 0;
 
         if (text.trim().length === 0) {
             placeholderMessage.style.display = 'block';
@@ -22,7 +22,7 @@ document.addEventListener('DOMContentLoaded', () => {
             placeholderMessage.style.display = 'none';
         }
 
-        
+
         const phrases = text.trim().split(' ');
 
         phrases.forEach((phrase, phraseIndex) => {
@@ -44,7 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     canvas.style.top = '0';
                     canvas.style.left = '0';
                     squareContainer.appendChild(canvas);
-                    
+
                     const charDisplay = document.createElement('div');
                     charDisplay.textContent = char;
                     charDisplay.style.fontSize = '3em';
@@ -54,24 +54,24 @@ document.addEventListener('DOMContentLoaded', () => {
                     charDisplay.style.top = '50%';
                     charDisplay.style.left = '50%';
                     charDisplay.style.transform = 'translate(-50%, -50%)';
-                    charDisplay.style.pointerEvents = 'none'; 
+                    charDisplay.style.pointerEvents = 'none';
                     squareContainer.appendChild(charDisplay);
 
                     phraseContainer.appendChild(squareContainer);
                     canvases.push(canvas);
 
-                    
+
                     squareContainer.addEventListener('click', () => {
                         const ctx = canvas.getContext('2d');
-                        ctx.clearRect(0, 0, canvas.width, canvas.height); 
+                        ctx.clearRect(0, 0, canvas.width, canvas.height);
                         ctx.fillStyle = '#333';
-                        ctx.font = '72px Arial'; 
+                        ctx.font = '72px Arial';
                         ctx.textAlign = 'center';
                         ctx.textBaseline = 'middle';
                         ctx.fillText(char, canvas.width / 2, canvas.height / 2);
                     });
 
-                  
+
                     let isDrawing = false;
                     const ctx = canvas.getContext('2d');
                     ctx.strokeStyle = '#333';
@@ -80,7 +80,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
                     const startDrawing = (e) => {
                         isDrawing = true;
-                        charDisplay.style.color = 'transparent'; 
+                        charDisplay.style.color = 'transparent';
                         const pos = getMousePos(canvas, e);
                         ctx.beginPath();
                         ctx.moveTo(pos.x, pos.y);
@@ -115,7 +115,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             y: clientY - rect.top
                         };
                     };
-                    
+
                     canvas.addEventListener('mousedown', startDrawing);
                     canvas.addEventListener('mousemove', draw);
                     canvas.addEventListener('mouseup', stopDrawing);
@@ -146,8 +146,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const japaneseText = event.target.value;
         generateJapaneseSquares(japaneseText);
     });
-    
-   
+
+
     clearAllButton.addEventListener('click', () => {
         canvases.forEach(canvas => {
             const ctx = canvas.getContext('2d');
@@ -155,7 +155,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
- 
+
     downloadPdfButton.addEventListener('click', async () => {
         if (canvases.length === 0) {
             alert('No hay caracteres para descargar. Por favor, escribe algunos en el campo de texto.');
@@ -166,34 +166,10 @@ document.addEventListener('DOMContentLoaded', () => {
         downloadPdfButton.disabled = true;
 
         try {
-            const gridContainer = document.getElementById('japanese-writing-grid');
-            const canvas = await html2canvas(gridContainer, { scale: 2 });
-            const imgData = canvas.toDataURL('image/png');
-
-            const { jsPDF } = window.jspdf;
-            const pdf = new jsPDF({
-                orientation: 'p',
-                unit: 'mm',
-                format: 'a4'
+            await window.AsianLanguagesPdf.downloadElementAsPdf({
+                element: document.getElementById('japanese-writing-grid'),
+                filename: 'japanese-worksheet.pdf',
             });
-
-            const imgWidth = pdf.internal.pageSize.getWidth() - 20;
-            const pageHeight = pdf.internal.pageSize.getHeight();
-            const imgHeight = (canvas.height * imgWidth) / canvas.width;
-            let heightLeft = imgHeight;
-            let position = 10;
-
-            pdf.addImage(imgData, 'PNG', 10, position, imgWidth, imgHeight);
-            heightLeft -= pageHeight;
-
-            while (heightLeft >= 0) {
-                position = heightLeft - imgHeight;
-                pdf.addPage();
-                pdf.addImage(imgData, 'PNG', 10, position, imgWidth, imgHeight);
-                heightLeft -= pageHeight;
-            }
-
-            pdf.save('japanese-worksheet.pdf');
             alert('PDF generado y descargado correctamente!');
         } catch (error) {
             console.error('Error generating PDF:', error);

--- a/docs/js/pdf-utils.js
+++ b/docs/js/pdf-utils.js
@@ -131,45 +131,17 @@
     };
 
     const createHanziPracticeBox = (character) => {
-        const box = createElement('div', 'hanzi-practice-box');
+        const box = createElement('div', 'tian-zi-ge-square border border-secondary hanzi-practice-box');
         box.dataset.char = character;
         box.style.width = `${HANZI_BOX_SIZE_PX}px`;
         box.style.height = `${HANZI_BOX_SIZE_PX}px`;
-        box.style.border = '1.2px solid #4f4f4f';
+        box.style.border = '1px solid #6c757d';
         box.style.position = 'relative';
-        box.style.display = 'inline-flex';
-        box.style.alignItems = 'center';
-        box.style.justifyContent = 'center';
-        box.style.background = '#ffffff';
+        box.style.backgroundColor = '#ffffff';
+        box.style.backgroundImage = 'url(\'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><line x1="0" y1="0" x2="100" y2="100" stroke="%23DDD" /><line x1="100" y1="0" x2="0" y2="100" stroke="%23DDD" /><line x1="50" y1="0" x2="50" y2="100" stroke="%23DDD" /><line x1="0" y1="50" x2="100" y2="50" stroke="%23DDD" /></svg>\')';
+        box.style.backgroundSize = 'contain';
+        box.style.backgroundRepeat = 'no-repeat';
         box.style.overflow = 'hidden';
-
-        const diagonalDown = createElement('span', 'hanzi-practice-line');
-        diagonalDown.style.position = 'absolute';
-        diagonalDown.style.inset = '0';
-        diagonalDown.style.background = 'linear-gradient(45deg, transparent calc(50% - 0.45px), #7d7d7d calc(50% - 0.45px), #7d7d7d calc(50% + 0.45px), transparent calc(50% + 0.45px))';
-        diagonalDown.style.opacity = '0.55';
-        diagonalDown.style.zIndex = '2';
-
-        const diagonalUp = createElement('span', 'hanzi-practice-line');
-        diagonalUp.style.position = 'absolute';
-        diagonalUp.style.inset = '0';
-        diagonalUp.style.background = 'linear-gradient(-45deg, transparent calc(50% - 0.45px), #7d7d7d calc(50% - 0.45px), #7d7d7d calc(50% + 0.45px), transparent calc(50% + 0.45px))';
-        diagonalUp.style.opacity = '0.55';
-        diagonalUp.style.zIndex = '2';
-
-        const vertical = createElement('span', 'hanzi-practice-line');
-        vertical.style.position = 'absolute';
-        vertical.style.inset = '0';
-        vertical.style.background = 'linear-gradient(90deg, transparent calc(50% - 0.35px), #8d8d8d calc(50% - 0.35px), #8d8d8d calc(50% + 0.35px), transparent calc(50% + 0.35px))';
-        vertical.style.opacity = '0.35';
-        vertical.style.zIndex = '3';
-
-        const horizontal = createElement('span', 'hanzi-practice-line');
-        horizontal.style.position = 'absolute';
-        horizontal.style.inset = '0';
-        horizontal.style.background = 'linear-gradient(0deg, transparent calc(50% - 0.35px), #8d8d8d calc(50% - 0.35px), #8d8d8d calc(50% + 0.35px), transparent calc(50% + 0.35px))';
-        horizontal.style.opacity = '0.35';
-        horizontal.style.zIndex = '3';
 
         const target = createElement('div', 'hanzi-practice-target');
         target.style.width = '100%';
@@ -177,17 +149,7 @@
         target.style.position = 'relative';
         target.style.zIndex = '1';
 
-        const glyph = createElement('span', 'hanzi-practice-glyph', character);
-        glyph.style.color = 'rgba(43, 43, 43, 0.22)';
-        glyph.style.fontFamily = '"Noto Serif CJK SC", "Noto Serif CJK", "SimSun", "Songti SC", "KaiTi", serif';
-        glyph.style.fontSize = '44px';
-        glyph.style.fontWeight = '400';
-        glyph.style.lineHeight = '1';
-        glyph.style.position = 'absolute';
-        glyph.style.zIndex = '1';
-        glyph.style.transform = 'translateY(-1px)';
-
-        box.append(target, glyph, diagonalDown, diagonalUp, vertical, horizontal);
+        box.appendChild(target);
         return box;
     };
 
@@ -265,23 +227,17 @@
         const boxes = Array.from(element.querySelectorAll('.hanzi-practice-box[data-char]'));
         boxes.forEach((box, index) => {
             const target = box.querySelector('.hanzi-practice-target');
-            const fallbackGlyph = box.querySelector('.hanzi-practice-glyph');
             if (!target) return;
 
             target.id = `pdf-hanzi-${Date.now()}-${index}`;
             target.innerHTML = '';
-            if (fallbackGlyph) fallbackGlyph.style.display = 'none';
 
             window.HanziWriter.create(target, box.dataset.char, {
                 width: HANZI_BOX_SIZE_PX,
                 height: HANZI_BOX_SIZE_PX,
-                padding: 2,
-                showOutline: true,
-                showCharacter: true,
-                strokeColor: '#2b2b2b',
-                radicalColor: '#006b2d',
-                outlineColor: '#9a9a9a',
-                strokeWidth: 2.2,
+                padding: 3,
+                radicalColor: '#168F16',
+                strokeWidth: 1.8,
             });
         });
 

--- a/docs/js/pdf-utils.js
+++ b/docs/js/pdf-utils.js
@@ -143,13 +143,22 @@
         box.style.backgroundRepeat = 'no-repeat';
         box.style.overflow = 'hidden';
 
-        const target = createElement('div', 'hanzi-practice-target');
-        target.style.width = '100%';
-        target.style.height = '100%';
-        target.style.position = 'relative';
-        target.style.zIndex = '1';
+        const glyph = createElement('span', 'hanzi-practice-glyph', character);
+        glyph.style.position = 'absolute';
+        glyph.style.inset = '0';
+        glyph.style.display = 'flex';
+        glyph.style.alignItems = 'center';
+        glyph.style.justifyContent = 'center';
+        glyph.style.color = '#111111';
+        glyph.style.opacity = '0.18';
+        glyph.style.fontFamily = '"Noto Serif SC", "KaiTi", "STKaiti", "Noto Serif CJK SC", "Noto Sans CJK SC", "Microsoft YaHei", "SimSun", serif';
+        glyph.style.fontSize = '76px';
+        glyph.style.fontWeight = '400';
+        glyph.style.lineHeight = '1';
+        glyph.style.transform = 'translateY(-2px)';
+        glyph.style.zIndex = '1';
 
-        box.appendChild(target);
+        box.appendChild(glyph);
         return box;
     };
 
@@ -217,32 +226,19 @@
         return worksheet;
     };
 
-    const waitForAnimationFrames = () => new Promise((resolve) => {
+    const ensureHanziGuideFont = () => {
+        if (document.querySelector('link[data-asian-languages-hanzi-font]')) return;
+
+        const fontLink = document.createElement('link');
+        fontLink.dataset.asianLanguagesHanziFont = 'true';
+        fontLink.rel = 'stylesheet';
+        fontLink.href = 'https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400&display=swap';
+        document.head.appendChild(fontLink);
+    };
+
+    const waitForPdfLayout = () => new Promise((resolve) => {
         requestAnimationFrame(() => requestAnimationFrame(resolve));
     });
-
-    const renderHanziWritersInWorksheet = async (element) => {
-        if (!window.HanziWriter) return;
-
-        const boxes = Array.from(element.querySelectorAll('.hanzi-practice-box[data-char]'));
-        boxes.forEach((box, index) => {
-            const target = box.querySelector('.hanzi-practice-target');
-            if (!target) return;
-
-            target.id = `pdf-hanzi-${Date.now()}-${index}`;
-            target.innerHTML = '';
-
-            window.HanziWriter.create(target, box.dataset.char, {
-                width: HANZI_BOX_SIZE_PX,
-                height: HANZI_BOX_SIZE_PX,
-                padding: 5,
-                radicalColor: '#168F16',
-                strokeWidth: 3,
-            });
-        });
-
-        await waitForAnimationFrames();
-    };
 
     const withHiddenPrintableElement = async (element, callback) => {
         const host = createElement('div', 'pdf-render-host');
@@ -302,7 +298,8 @@
             });
 
             await withHiddenPrintableElement(worksheet, async (element) => {
-                await renderHanziWritersInWorksheet(element);
+                ensureHanziGuideFont();
+                await waitForPdfLayout();
                 const canvas = await renderElementToCanvas(element);
                 const imgData = canvas.toDataURL('image/png');
                 if (pageIndex > 0) pdf.addPage();

--- a/docs/js/pdf-utils.js
+++ b/docs/js/pdf-utils.js
@@ -96,9 +96,11 @@
     };
 
 
-    const HANZI_BOX_SIZE_PX = 58;
+    const HANZI_BOX_SIZE_PX = 60;
     const HANZI_PAGE_WIDTH_PX = 794;
     const HANZI_PAGE_MIN_HEIGHT_PX = 1123;
+    const HANZI_BOXES_PER_PAGE = 108;
+    const MAX_HANZI_PDF_CHARACTERS = 720;
 
     const isHanziPracticeCharacter = (character) => /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(character);
 
@@ -109,37 +111,87 @@
         return element;
     };
 
+    const chunkCharacters = (characters, size) => {
+        const chunks = [];
+        for (let index = 0; index < characters.length; index += size) {
+            chunks.push(characters.slice(index, index + size));
+        }
+        return chunks;
+    };
+
+    const downloadBlob = (blob, filename) => {
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        URL.revokeObjectURL(url);
+    };
+
     const createHanziPracticeBox = (character) => {
         const box = createElement('div', 'hanzi-practice-box');
+        box.dataset.char = character;
         box.style.width = `${HANZI_BOX_SIZE_PX}px`;
         box.style.height = `${HANZI_BOX_SIZE_PX}px`;
-        box.style.border = '1.5px solid #8a8a8a';
+        box.style.border = '1.2px solid #4f4f4f';
         box.style.position = 'relative';
         box.style.display = 'inline-flex';
         box.style.alignItems = 'center';
         box.style.justifyContent = 'center';
-        box.style.background = [
-            'linear-gradient(45deg, transparent calc(50% - 0.5px), #d5d5d5 calc(50% - 0.5px), #d5d5d5 calc(50% + 0.5px), transparent calc(50% + 0.5px))',
-            'linear-gradient(-45deg, transparent calc(50% - 0.5px), #d5d5d5 calc(50% - 0.5px), #d5d5d5 calc(50% + 0.5px), transparent calc(50% + 0.5px))',
-            'linear-gradient(90deg, transparent calc(50% - 0.5px), #eeeeee calc(50% - 0.5px), #eeeeee calc(50% + 0.5px), transparent calc(50% + 0.5px))',
-            'linear-gradient(0deg, transparent calc(50% - 0.5px), #eeeeee calc(50% - 0.5px), #eeeeee calc(50% + 0.5px), transparent calc(50% + 0.5px))',
-            '#ffffff',
-        ].join(', ');
+        box.style.background = '#ffffff';
+        box.style.overflow = 'hidden';
+
+        const diagonalDown = createElement('span', 'hanzi-practice-line');
+        diagonalDown.style.position = 'absolute';
+        diagonalDown.style.inset = '0';
+        diagonalDown.style.background = 'linear-gradient(45deg, transparent calc(50% - 0.45px), #7d7d7d calc(50% - 0.45px), #7d7d7d calc(50% + 0.45px), transparent calc(50% + 0.45px))';
+        diagonalDown.style.opacity = '0.55';
+        diagonalDown.style.zIndex = '2';
+
+        const diagonalUp = createElement('span', 'hanzi-practice-line');
+        diagonalUp.style.position = 'absolute';
+        diagonalUp.style.inset = '0';
+        diagonalUp.style.background = 'linear-gradient(-45deg, transparent calc(50% - 0.45px), #7d7d7d calc(50% - 0.45px), #7d7d7d calc(50% + 0.45px), transparent calc(50% + 0.45px))';
+        diagonalUp.style.opacity = '0.55';
+        diagonalUp.style.zIndex = '2';
+
+        const vertical = createElement('span', 'hanzi-practice-line');
+        vertical.style.position = 'absolute';
+        vertical.style.inset = '0';
+        vertical.style.background = 'linear-gradient(90deg, transparent calc(50% - 0.35px), #8d8d8d calc(50% - 0.35px), #8d8d8d calc(50% + 0.35px), transparent calc(50% + 0.35px))';
+        vertical.style.opacity = '0.35';
+        vertical.style.zIndex = '3';
+
+        const horizontal = createElement('span', 'hanzi-practice-line');
+        horizontal.style.position = 'absolute';
+        horizontal.style.inset = '0';
+        horizontal.style.background = 'linear-gradient(0deg, transparent calc(50% - 0.35px), #8d8d8d calc(50% - 0.35px), #8d8d8d calc(50% + 0.35px), transparent calc(50% + 0.35px))';
+        horizontal.style.opacity = '0.35';
+        horizontal.style.zIndex = '3';
+
+        const target = createElement('div', 'hanzi-practice-target');
+        target.style.width = '100%';
+        target.style.height = '100%';
+        target.style.position = 'relative';
+        target.style.zIndex = '1';
 
         const glyph = createElement('span', 'hanzi-practice-glyph', character);
-        glyph.style.color = 'rgba(0, 0, 0, 0.16)';
+        glyph.style.color = 'rgba(43, 43, 43, 0.22)';
         glyph.style.fontFamily = '"Noto Serif CJK SC", "Noto Serif CJK", "SimSun", "Songti SC", "KaiTi", serif';
-        glyph.style.fontSize = '42px';
+        glyph.style.fontSize = '44px';
         glyph.style.fontWeight = '400';
         glyph.style.lineHeight = '1';
+        glyph.style.position = 'absolute';
+        glyph.style.zIndex = '1';
         glyph.style.transform = 'translateY(-1px)';
-        box.appendChild(glyph);
 
+        box.append(target, glyph, diagonalDown, diagonalUp, vertical, horizontal);
         return box;
     };
 
-    const createHanziWorksheetTemplate = ({ characters, date, location }) => {
-        const printableCharacters = Array.from(characters).filter((character) => character.trim().length > 0);
+    const createHanziWorksheetPage = ({ characters, date, location }) => {
         const worksheet = createElement('section', 'hanzi-printable-worksheet');
         worksheet.setAttribute('aria-hidden', 'true');
         worksheet.style.width = `${HANZI_PAGE_WIDTH_PX}px`;
@@ -148,16 +200,16 @@
         worksheet.style.color = '#111111';
         worksheet.style.fontFamily = 'Arial, "Microsoft YaHei", "PingFang SC", sans-serif';
         worksheet.style.boxSizing = 'border-box';
-        worksheet.style.padding = '0 48px 48px';
+        worksheet.style.padding = '0 52px 52px';
 
         const header = createElement('header', 'hanzi-worksheet-header');
-        header.style.height = '72px';
+        header.style.height = '84px';
         header.style.display = 'grid';
         header.style.gridTemplateColumns = '1fr auto 1fr';
         header.style.alignItems = 'center';
         header.style.borderBottom = '2px solid #ff2f55';
-        header.style.margin = '0 -48px 26px';
-        header.style.padding = '0 48px';
+        header.style.margin = '0 -52px 30px';
+        header.style.padding = '0 52px';
         header.style.boxSizing = 'border-box';
         header.style.background = '#f7f7f7';
 
@@ -178,14 +230,14 @@
         worksheet.appendChild(header);
 
         const grid = createElement('div', 'hanzi-worksheet-grid');
-        grid.style.display = 'flex';
-        grid.style.flexWrap = 'wrap';
-        grid.style.alignItems = 'center';
-        grid.style.alignContent = 'flex-start';
-        grid.style.columnGap = '14px';
-        grid.style.rowGap = '18px';
+        grid.style.display = 'grid';
+        grid.style.gridTemplateColumns = `repeat(9, ${HANZI_BOX_SIZE_PX}px)`;
+        grid.style.gridAutoRows = `${HANZI_BOX_SIZE_PX}px`;
+        grid.style.gap = '18px 14px';
+        grid.style.alignContent = 'start';
+        grid.style.justifyContent = 'center';
 
-        printableCharacters.forEach((character) => {
+        characters.forEach((character) => {
             if (isHanziPracticeCharacter(character)) {
                 grid.appendChild(createHanziPracticeBox(character));
                 return;
@@ -201,6 +253,39 @@
 
         worksheet.appendChild(grid);
         return worksheet;
+    };
+
+    const waitForAnimationFrames = () => new Promise((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(resolve));
+    });
+
+    const renderHanziWritersInWorksheet = async (element) => {
+        if (!window.HanziWriter) return;
+
+        const boxes = Array.from(element.querySelectorAll('.hanzi-practice-box[data-char]'));
+        boxes.forEach((box, index) => {
+            const target = box.querySelector('.hanzi-practice-target');
+            const fallbackGlyph = box.querySelector('.hanzi-practice-glyph');
+            if (!target) return;
+
+            target.id = `pdf-hanzi-${Date.now()}-${index}`;
+            target.innerHTML = '';
+            if (fallbackGlyph) fallbackGlyph.style.display = 'none';
+
+            window.HanziWriter.create(target, box.dataset.char, {
+                width: HANZI_BOX_SIZE_PX,
+                height: HANZI_BOX_SIZE_PX,
+                padding: 2,
+                showOutline: true,
+                showCharacter: true,
+                strokeColor: '#2b2b2b',
+                radicalColor: '#006b2d',
+                outlineColor: '#9a9a9a',
+                strokeWidth: 2.2,
+            });
+        });
+
+        await waitForAnimationFrames();
     };
 
     const withHiddenPrintableElement = async (element, callback) => {
@@ -220,24 +305,89 @@
         }
     };
 
+    const tryDownloadHanziWorksheetFromFirebase = async ({ characters, filename, date, location }) => {
+        const response = await fetch('/generarHanziPDF', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                characters,
+                filename: filename.replace(/\.pdf$/i, ''),
+                date,
+                location,
+            }),
+        });
+
+        const contentType = response.headers.get('content-type') || '';
+        if (!response.ok || !contentType.includes('application/pdf')) {
+            const errorMessage = await response.text().catch(() => 'No se pudo generar el PDF en Firebase.');
+            throw new Error(errorMessage || 'No se pudo generar el PDF en Firebase.');
+        }
+
+        const pdfBlob = await response.blob();
+        downloadBlob(pdfBlob, filename);
+    };
+
+    const downloadHanziWorksheetLocally = async ({ characters, filename, date, location }) => {
+        const pages = chunkCharacters(characters, HANZI_BOXES_PER_PAGE);
+        const { jsPDF } = window.jspdf;
+        const pdf = new jsPDF({
+            orientation: 'p',
+            unit: 'mm',
+            format: 'a4',
+        });
+
+        for (let pageIndex = 0; pageIndex < pages.length; pageIndex += 1) {
+            const worksheet = createHanziWorksheetPage({
+                characters: pages[pageIndex],
+                date,
+                location,
+            });
+
+            await withHiddenPrintableElement(worksheet, async (element) => {
+                await renderHanziWritersInWorksheet(element);
+                const canvas = await renderElementToCanvas(element);
+                const imgData = canvas.toDataURL('image/png');
+                if (pageIndex > 0) pdf.addPage();
+                pdf.addImage(imgData, 'PNG', 0, 0, 210, 297);
+            });
+        }
+
+        pdf.save(filename);
+    };
+
     const downloadHanziWorksheetPdf = async ({ characters, filename = 'hanzi-worksheet.pdf', date, location }) => {
-        if (!characters || Array.from(characters.replace(/\s/g, '')).length === 0) {
+        ensurePdfDependencies();
+
+        const printableCharacters = Array.from((characters || '').replace(/\s/g, ''));
+        if (printableCharacters.length === 0) {
             throw new Error('No hay caracteres Hanzi para generar el PDF.');
         }
 
-        const formattedDate = date || new Date().toLocaleDateString('es-ES');
-        const worksheet = createHanziWorksheetTemplate({
-            characters,
-            date: formattedDate,
-            location,
-        });
+        if (printableCharacters.length > MAX_HANZI_PDF_CHARACTERS) {
+            throw new Error(`Por ahora el PDF permite máximo ${MAX_HANZI_PDF_CHARACTERS} caracteres para evitar archivos demasiado pesados.`);
+        }
 
-        await withHiddenPrintableElement(worksheet, async (element) => {
-            await downloadElementAsPdf({
-                element,
+        const formattedDate = date || new Date().toLocaleDateString('es-ES');
+        const charactersText = printableCharacters.join('');
+
+        try {
+            await tryDownloadHanziWorksheetFromFirebase({
+                characters: charactersText,
                 filename,
+                date: formattedDate,
+                location,
             });
-        });
+        } catch (firebaseError) {
+            console.warn('Firebase PDF generation unavailable; using browser fallback.', firebaseError);
+            await downloadHanziWorksheetLocally({
+                characters: printableCharacters,
+                filename,
+                date: formattedDate,
+                location,
+            });
+        }
     };
 
     window.AsianLanguagesPdf = {

--- a/docs/js/pdf-utils.js
+++ b/docs/js/pdf-utils.js
@@ -1,0 +1,101 @@
+(function (window) {
+    const DEFAULT_MARGIN_MM = 10;
+
+    const ensurePdfDependencies = () => {
+        if (typeof window.html2canvas !== 'function') {
+            throw new Error('html2canvas no está cargado. Revisa la conexión al CDN antes de descargar el PDF.');
+        }
+
+        if (!window.jspdf || typeof window.jspdf.jsPDF !== 'function') {
+            throw new Error('jsPDF no está cargado. Revisa la conexión al CDN antes de descargar el PDF.');
+        }
+    };
+
+    const waitForFonts = async () => {
+        if (document.fonts && typeof document.fonts.ready?.then === 'function') {
+            await document.fonts.ready;
+        }
+    };
+
+    const renderElementToCanvas = async (element) => {
+        if (!element) {
+            throw new Error('No se encontró el elemento que se debe convertir a PDF.');
+        }
+
+        await waitForFonts();
+
+        const scale = Math.max(2, Math.ceil(window.devicePixelRatio || 1));
+        const canvas = await window.html2canvas(element, {
+            backgroundColor: '#ffffff',
+            logging: false,
+            scale,
+            useCORS: true,
+            windowWidth: document.documentElement.scrollWidth,
+        });
+
+        if (!canvas.width || !canvas.height) {
+            throw new Error('No se pudo capturar contenido visible para el PDF.');
+        }
+
+        return canvas;
+    };
+
+    const addCanvasToPdfPages = (pdf, canvas, margin = DEFAULT_MARGIN_MM) => {
+        const imgData = canvas.toDataURL('image/png');
+        const pageWidth = pdf.internal.pageSize.getWidth();
+        const pageHeight = pdf.internal.pageSize.getHeight();
+        const printableWidth = pageWidth - (margin * 2);
+        const printableHeight = pageHeight - (margin * 2);
+        const imgHeight = (canvas.height * printableWidth) / canvas.width;
+
+        let renderedHeight = 0;
+
+        pdf.addImage(imgData, 'PNG', margin, margin, printableWidth, imgHeight);
+        renderedHeight += printableHeight;
+
+        while (renderedHeight < imgHeight) {
+            pdf.addPage();
+            pdf.addImage(
+                imgData,
+                'PNG',
+                margin,
+                margin - renderedHeight,
+                printableWidth,
+                imgHeight
+            );
+            renderedHeight += printableHeight;
+        }
+    };
+
+    const downloadElementAsPdf = async ({ element, filename, title }) => {
+        ensurePdfDependencies();
+
+        const canvas = await renderElementToCanvas(element);
+        const { jsPDF } = window.jspdf;
+        const pdf = new jsPDF({
+            orientation: 'p',
+            unit: 'mm',
+            format: 'a4',
+        });
+
+        if (title) {
+            const pageWidth = pdf.internal.pageSize.getWidth();
+            const today = new Date().toLocaleDateString('es-ES');
+            pdf.setFont('helvetica', 'bold');
+            pdf.setFontSize(16);
+            pdf.text(title, pageWidth / 2, 14, { align: 'center' });
+            pdf.setFont('helvetica', 'normal');
+            pdf.setFontSize(11);
+            pdf.text(`Fecha: ${today}`, pageWidth / 2, 21, { align: 'center' });
+            addCanvasToPdfPages(pdf, canvas, 28);
+        } else {
+            addCanvasToPdfPages(pdf, canvas);
+        }
+
+        pdf.save(filename);
+    };
+
+    window.AsianLanguagesPdf = {
+        downloadElementAsPdf,
+    };
+})(window);

--- a/docs/js/pdf-utils.js
+++ b/docs/js/pdf-utils.js
@@ -96,10 +96,10 @@
     };
 
 
-    const HANZI_BOX_SIZE_PX = 60;
+    const HANZI_BOX_SIZE_PX = 100;
     const HANZI_PAGE_WIDTH_PX = 794;
     const HANZI_PAGE_MIN_HEIGHT_PX = 1123;
-    const HANZI_BOXES_PER_PAGE = 108;
+    const HANZI_BOXES_PER_PAGE = 48;
     const MAX_HANZI_PDF_CHARACTERS = 720;
 
     const isHanziPracticeCharacter = (character) => /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(character);
@@ -193,9 +193,9 @@
 
         const grid = createElement('div', 'hanzi-worksheet-grid');
         grid.style.display = 'grid';
-        grid.style.gridTemplateColumns = `repeat(9, ${HANZI_BOX_SIZE_PX}px)`;
+        grid.style.gridTemplateColumns = `repeat(6, ${HANZI_BOX_SIZE_PX}px)`;
         grid.style.gridAutoRows = `${HANZI_BOX_SIZE_PX}px`;
-        grid.style.gap = '18px 14px';
+        grid.style.gap = '16px 14px';
         grid.style.alignContent = 'start';
         grid.style.justifyContent = 'center';
 
@@ -235,9 +235,9 @@
             window.HanziWriter.create(target, box.dataset.char, {
                 width: HANZI_BOX_SIZE_PX,
                 height: HANZI_BOX_SIZE_PX,
-                padding: 3,
+                padding: 5,
                 radicalColor: '#168F16',
-                strokeWidth: 1.8,
+                strokeWidth: 3,
             });
         });
 

--- a/docs/js/pdf-utils.js
+++ b/docs/js/pdf-utils.js
@@ -95,7 +95,153 @@
         pdf.save(filename);
     };
 
+
+    const HANZI_BOX_SIZE_PX = 58;
+    const HANZI_PAGE_WIDTH_PX = 794;
+    const HANZI_PAGE_MIN_HEIGHT_PX = 1123;
+
+    const isHanziPracticeCharacter = (character) => /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(character);
+
+    const createElement = (tagName, className, textContent) => {
+        const element = document.createElement(tagName);
+        if (className) element.className = className;
+        if (textContent) element.textContent = textContent;
+        return element;
+    };
+
+    const createHanziPracticeBox = (character) => {
+        const box = createElement('div', 'hanzi-practice-box');
+        box.style.width = `${HANZI_BOX_SIZE_PX}px`;
+        box.style.height = `${HANZI_BOX_SIZE_PX}px`;
+        box.style.border = '1.5px solid #8a8a8a';
+        box.style.position = 'relative';
+        box.style.display = 'inline-flex';
+        box.style.alignItems = 'center';
+        box.style.justifyContent = 'center';
+        box.style.background = [
+            'linear-gradient(45deg, transparent calc(50% - 0.5px), #d5d5d5 calc(50% - 0.5px), #d5d5d5 calc(50% + 0.5px), transparent calc(50% + 0.5px))',
+            'linear-gradient(-45deg, transparent calc(50% - 0.5px), #d5d5d5 calc(50% - 0.5px), #d5d5d5 calc(50% + 0.5px), transparent calc(50% + 0.5px))',
+            'linear-gradient(90deg, transparent calc(50% - 0.5px), #eeeeee calc(50% - 0.5px), #eeeeee calc(50% + 0.5px), transparent calc(50% + 0.5px))',
+            'linear-gradient(0deg, transparent calc(50% - 0.5px), #eeeeee calc(50% - 0.5px), #eeeeee calc(50% + 0.5px), transparent calc(50% + 0.5px))',
+            '#ffffff',
+        ].join(', ');
+
+        const glyph = createElement('span', 'hanzi-practice-glyph', character);
+        glyph.style.color = 'rgba(0, 0, 0, 0.16)';
+        glyph.style.fontFamily = '"Noto Serif CJK SC", "Noto Serif CJK", "SimSun", "Songti SC", "KaiTi", serif';
+        glyph.style.fontSize = '42px';
+        glyph.style.fontWeight = '400';
+        glyph.style.lineHeight = '1';
+        glyph.style.transform = 'translateY(-1px)';
+        box.appendChild(glyph);
+
+        return box;
+    };
+
+    const createHanziWorksheetTemplate = ({ characters, date, location }) => {
+        const printableCharacters = Array.from(characters).filter((character) => character.trim().length > 0);
+        const worksheet = createElement('section', 'hanzi-printable-worksheet');
+        worksheet.setAttribute('aria-hidden', 'true');
+        worksheet.style.width = `${HANZI_PAGE_WIDTH_PX}px`;
+        worksheet.style.minHeight = `${HANZI_PAGE_MIN_HEIGHT_PX}px`;
+        worksheet.style.background = '#ffffff';
+        worksheet.style.color = '#111111';
+        worksheet.style.fontFamily = 'Arial, "Microsoft YaHei", "PingFang SC", sans-serif';
+        worksheet.style.boxSizing = 'border-box';
+        worksheet.style.padding = '0 48px 48px';
+
+        const header = createElement('header', 'hanzi-worksheet-header');
+        header.style.height = '72px';
+        header.style.display = 'grid';
+        header.style.gridTemplateColumns = '1fr auto 1fr';
+        header.style.alignItems = 'center';
+        header.style.borderBottom = '2px solid #ff2f55';
+        header.style.margin = '0 -48px 26px';
+        header.style.padding = '0 48px';
+        header.style.boxSizing = 'border-box';
+        header.style.background = '#f7f7f7';
+
+        const dateLabel = createElement('div', 'hanzi-worksheet-meta', `日期: ${date || '__________'}`);
+        dateLabel.style.fontSize = '17px';
+        dateLabel.style.fontWeight = '700';
+        const title = createElement('h1', 'hanzi-worksheet-title', '汉字书写练习');
+        title.style.margin = '0';
+        title.style.fontSize = '28px';
+        title.style.fontWeight = '800';
+        title.style.letterSpacing = '2px';
+        const locationLabel = createElement('div', 'hanzi-worksheet-meta', `地点: ${location || '__________'}`);
+        locationLabel.style.fontSize = '17px';
+        locationLabel.style.fontWeight = '700';
+        locationLabel.style.textAlign = 'right';
+
+        header.append(dateLabel, title, locationLabel);
+        worksheet.appendChild(header);
+
+        const grid = createElement('div', 'hanzi-worksheet-grid');
+        grid.style.display = 'flex';
+        grid.style.flexWrap = 'wrap';
+        grid.style.alignItems = 'center';
+        grid.style.alignContent = 'flex-start';
+        grid.style.columnGap = '14px';
+        grid.style.rowGap = '18px';
+
+        printableCharacters.forEach((character) => {
+            if (isHanziPracticeCharacter(character)) {
+                grid.appendChild(createHanziPracticeBox(character));
+                return;
+            }
+
+            const punctuation = createElement('span', 'hanzi-worksheet-punctuation', character);
+            punctuation.style.color = 'rgba(0, 0, 0, 0.28)';
+            punctuation.style.fontSize = '32px';
+            punctuation.style.minWidth = '18px';
+            punctuation.style.textAlign = 'center';
+            grid.appendChild(punctuation);
+        });
+
+        worksheet.appendChild(grid);
+        return worksheet;
+    };
+
+    const withHiddenPrintableElement = async (element, callback) => {
+        const host = createElement('div', 'pdf-render-host');
+        host.style.position = 'fixed';
+        host.style.left = '-10000px';
+        host.style.top = '0';
+        host.style.zIndex = '-1';
+        host.style.background = '#ffffff';
+        host.appendChild(element);
+        document.body.appendChild(host);
+
+        try {
+            return await callback(element);
+        } finally {
+            host.remove();
+        }
+    };
+
+    const downloadHanziWorksheetPdf = async ({ characters, filename = 'hanzi-worksheet.pdf', date, location }) => {
+        if (!characters || Array.from(characters.replace(/\s/g, '')).length === 0) {
+            throw new Error('No hay caracteres Hanzi para generar el PDF.');
+        }
+
+        const formattedDate = date || new Date().toLocaleDateString('es-ES');
+        const worksheet = createHanziWorksheetTemplate({
+            characters,
+            date: formattedDate,
+            location,
+        });
+
+        await withHiddenPrintableElement(worksheet, async (element) => {
+            await downloadElementAsPdf({
+                element,
+                filename,
+            });
+        });
+    };
+
     window.AsianLanguagesPdf = {
         downloadElementAsPdf,
+        downloadHanziWorksheetPdf,
     };
 })(window);

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "public": ".",
+    "public": "public",
     "ignore": [
       "firebase.json",
       "**/.*",

--- a/firebase.json
+++ b/firebase.json
@@ -6,6 +6,12 @@
       "**/.*",
       "**/node_modules/**",
       "functions/**"
+    ],
+    "rewrites": [
+      {
+        "source": "/generarHanziPDF",
+        "function": "generarHanziPDF"
+      }
     ]
   },
   "functions": [
@@ -13,5 +19,15 @@
       "source": "functions",
       "codebase": "default"
     }
-  ]
+  ],
+  "emulators": {
+    "hosting": {
+      "host": "0.0.0.0",
+      "port": 5000
+    },
+    "functions": {
+      "host": "0.0.0.0",
+      "port": 5001
+    }
+  }
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -104,22 +104,10 @@ const createHanziWorksheetHtml = ({ characters, date, location }) => {
       background: #ffffff;
       overflow: hidden;
     }
-    .hanzi-square::before,
-    .hanzi-square::after,
-    .hanzi-target::before,
-    .hanzi-target::after {
-      content: "";
-      position: absolute;
-      inset: 0;
-      pointer-events: none;
-    }
-    .hanzi-square::before {
-      background: linear-gradient(45deg, transparent calc(50% - 0.45px), #7d7d7d calc(50% - 0.45px), #7d7d7d calc(50% + 0.45px), transparent calc(50% + 0.45px));
-      opacity: 0.55;
-    }
-    .hanzi-square::after {
-      background: linear-gradient(-45deg, transparent calc(50% - 0.45px), #7d7d7d calc(50% - 0.45px), #7d7d7d calc(50% + 0.45px), transparent calc(50% + 0.45px));
-      opacity: 0.55;
+    .hanzi-square {
+      background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><line x1="0" y1="0" x2="100" y2="100" stroke="%23DDD" /><line x1="100" y1="0" x2="0" y2="100" stroke="%23DDD" /><line x1="50" y1="0" x2="50" y2="100" stroke="%23DDD" /><line x1="0" y1="50" x2="100" y2="50" stroke="%23DDD" /></svg>');
+      background-size: contain;
+      background-repeat: no-repeat;
     }
     .hanzi-target {
       width: 100%;
@@ -127,17 +115,6 @@ const createHanziWorksheetHtml = ({ characters, date, location }) => {
       position: relative;
       z-index: 1;
     }
-    .hanzi-target::before {
-      background: linear-gradient(90deg, transparent calc(50% - 0.35px), #8d8d8d calc(50% - 0.35px), #8d8d8d calc(50% + 0.35px), transparent calc(50% + 0.35px));
-      opacity: 0.35;
-      z-index: 2;
-    }
-    .hanzi-target::after {
-      background: linear-gradient(0deg, transparent calc(50% - 0.35px), #8d8d8d calc(50% - 0.35px), #8d8d8d calc(50% + 0.35px), transparent calc(50% + 0.35px));
-      opacity: 0.35;
-      z-index: 2;
-    }
-    .hanzi-target svg { position: relative; z-index: 1; }
   </style>
 </head>
 <body>
@@ -151,13 +128,9 @@ const createHanziWorksheetHtml = ({ characters, date, location }) => {
       HanziWriter.create(target.id, character, {
         width: 60,
         height: 60,
-        padding: 2,
-        showOutline: true,
-        showCharacter: true,
-        strokeColor: '#2b2b2b',
-        radicalColor: '#006b2d',
-        outlineColor: '#9a9a9a',
-        strokeWidth: 2.2,
+        padding: 3,
+        radicalColor: '#168F16',
+        strokeWidth: 1.8,
       });
     });
     requestAnimationFrame(() => {

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,7 +1,181 @@
 const { onRequest } = require("firebase-functions/v2/https");
-const { defineSecret } = require("firebase-functions/params");
 const puppeteer = require("puppeteer-core");
 const chromium = require("@sparticuz/chromium");
+
+const HANZI_BOXES_PER_PAGE = 108;
+const MAX_HANZI_PDF_CHARACTERS = 720;
+
+const normalizeFilename = (filename = "documento") => filename
+  .toString()
+  .replace(/[^a-z0-9-_]/gi, "-")
+  .replace(/-+/g, "-")
+  .replace(/^-|-$/g, "") || "documento";
+
+const chunkArray = (items, size) => {
+  const chunks = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+};
+
+const escapeHtml = (value) => value
+  .toString()
+  .replace(/&/g, "&amp;")
+  .replace(/</g, "&lt;")
+  .replace(/>/g, "&gt;")
+  .replace(/"/g, "&quot;")
+  .replace(/'/g, "&#039;");
+
+const getCharactersFromText = (characters = "") => Array.from(characters)
+  .filter((character) => character.trim().length > 0);
+
+const createHanziWorksheetHtml = ({ characters, date, location }) => {
+  const pages = chunkArray(characters, HANZI_BOXES_PER_PAGE);
+  const safeDate = escapeHtml(date || "__________");
+  const safeLocation = escapeHtml(location || "__________");
+  const pageMarkup = pages.map((pageCharacters, pageIndex) => `
+    <section class="worksheet-page">
+      <header class="worksheet-header">
+        <div class="worksheet-meta">日期: ${safeDate}</div>
+        <h1>汉字书写练习</h1>
+        <div class="worksheet-meta worksheet-location">地点: ${safeLocation}</div>
+      </header>
+      <main class="worksheet-grid">
+        ${pageCharacters.map((character, characterIndex) => `
+          <div class="hanzi-square" data-char="${escapeHtml(character)}">
+            <div id="hanzi-${pageIndex}-${characterIndex}" class="hanzi-target"></div>
+          </div>
+        `).join("")}
+      </main>
+    </section>
+  `).join("");
+
+  return `<!DOCTYPE html>
+<html lang="zh-Hans">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>汉字书写练习</title>
+  <script src="https://cdn.jsdelivr.net/npm/hanzi-writer@2.2.2/dist/hanzi-writer.min.js"></script>
+  <style>
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; background: #ffffff; }
+    body { font-family: Arial, "Microsoft YaHei", "PingFang SC", sans-serif; color: #111111; }
+    .worksheet-page {
+      width: 210mm;
+      min-height: 297mm;
+      padding: 0 14mm 14mm;
+      background: #ffffff;
+      page-break-after: always;
+    }
+    .worksheet-page:last-child { page-break-after: auto; }
+    .worksheet-header {
+      height: 22mm;
+      display: grid;
+      grid-template-columns: 1fr auto 1fr;
+      align-items: center;
+      border-bottom: 1.6px solid #ff2f55;
+      margin: 0 -14mm 8mm;
+      padding: 0 14mm;
+      background: #f7f7f7;
+    }
+    .worksheet-header h1 {
+      margin: 0;
+      font-size: 24px;
+      font-weight: 800;
+      letter-spacing: 2px;
+    }
+    .worksheet-meta { font-size: 15px; font-weight: 700; }
+    .worksheet-location { text-align: right; }
+    .worksheet-grid {
+      display: grid;
+      grid-template-columns: repeat(9, 16mm);
+      grid-auto-rows: 16mm;
+      gap: 5mm 4mm;
+      align-content: start;
+      justify-content: center;
+    }
+    .hanzi-square {
+      width: 16mm;
+      height: 16mm;
+      position: relative;
+      border: 1.1px solid #4f4f4f;
+      background: #ffffff;
+      overflow: hidden;
+    }
+    .hanzi-square::before,
+    .hanzi-square::after,
+    .hanzi-target::before,
+    .hanzi-target::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+    }
+    .hanzi-square::before {
+      background: linear-gradient(45deg, transparent calc(50% - 0.45px), #7d7d7d calc(50% - 0.45px), #7d7d7d calc(50% + 0.45px), transparent calc(50% + 0.45px));
+      opacity: 0.55;
+    }
+    .hanzi-square::after {
+      background: linear-gradient(-45deg, transparent calc(50% - 0.45px), #7d7d7d calc(50% - 0.45px), #7d7d7d calc(50% + 0.45px), transparent calc(50% + 0.45px));
+      opacity: 0.55;
+    }
+    .hanzi-target {
+      width: 100%;
+      height: 100%;
+      position: relative;
+      z-index: 1;
+    }
+    .hanzi-target::before {
+      background: linear-gradient(90deg, transparent calc(50% - 0.35px), #8d8d8d calc(50% - 0.35px), #8d8d8d calc(50% + 0.35px), transparent calc(50% + 0.35px));
+      opacity: 0.35;
+      z-index: 2;
+    }
+    .hanzi-target::after {
+      background: linear-gradient(0deg, transparent calc(50% - 0.35px), #8d8d8d calc(50% - 0.35px), #8d8d8d calc(50% + 0.35px), transparent calc(50% + 0.35px));
+      opacity: 0.35;
+      z-index: 2;
+    }
+    .hanzi-target svg { position: relative; z-index: 1; }
+  </style>
+</head>
+<body>
+  ${pageMarkup}
+  <script>
+    window.__HANZI_WORKSHEET_READY__ = false;
+    const renderTargets = Array.from(document.querySelectorAll('.hanzi-square'));
+    renderTargets.forEach((square) => {
+      const target = square.querySelector('.hanzi-target');
+      const character = square.dataset.char;
+      HanziWriter.create(target.id, character, {
+        width: 60,
+        height: 60,
+        padding: 2,
+        showOutline: true,
+        showCharacter: true,
+        strokeColor: '#2b2b2b',
+        radicalColor: '#006b2d',
+        outlineColor: '#9a9a9a',
+        strokeWidth: 2.2,
+      });
+    });
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        window.__HANZI_WORKSHEET_READY__ = true;
+      });
+    });
+  </script>
+</body>
+</html>`;
+};
+
+const createBrowser = async () => puppeteer.launch({
+  args: chromium.args,
+  defaultViewport: chromium.defaultViewport,
+  executablePath: await chromium.executablePath(),
+  headless: chromium.headless,
+});
 
 /**
  * Cloud Function: generarPDF
@@ -9,20 +183,14 @@ const chromium = require("@sparticuz/chromium");
  * Devuelve: archivo PDF binario
  */
 exports.generarPDF = onRequest({
-  // Permite llamadas desde tu dominio (CORS)
   cors: true,
-  // Memoria necesaria para Chromium
   memory: "1GiB",
-  // Tiempo máximo de ejecución (30 segundos)
   timeoutSeconds: 30,
 }, async (req, res) => {
-
-  // Solo aceptar peticiones POST
   if (req.method !== "POST") {
     return res.status(405).send("Método no permitido");
   }
 
-  // Extraer el HTML que envía el frontend
   const { html, filename = "documento" } = req.body;
 
   if (!html) {
@@ -32,25 +200,16 @@ exports.generarPDF = onRequest({
   let browser = null;
 
   try {
-    // Iniciar el navegador Chromium en el servidor
-    browser = await puppeteer.launch({
-      args: chromium.args,
-      defaultViewport: chromium.defaultViewport,
-      executablePath: await chromium.executablePath(),
-      headless: chromium.headless,
-    });
-
+    browser = await createBrowser();
     const page = await browser.newPage();
 
-    // Cargar el HTML con los caracteres chinos/coreanos
     await page.setContent(html, {
-      waitUntil: "networkidle0",  // esperar a que carguen las fuentes
+      waitUntil: "networkidle0",
     });
 
-    // Generar el PDF con tamaño A4
     const pdfBuffer = await page.pdf({
       format: "A4",
-      printBackground: true,       // incluir colores de fondo
+      printBackground: true,
       margin: {
         top: "20mm",
         right: "20mm",
@@ -59,17 +218,81 @@ exports.generarPDF = onRequest({
       },
     });
 
-    // Enviar el PDF como respuesta
     res.set("Content-Type", "application/pdf");
-    res.set("Content-Disposition", `attachment; filename="${filename}.pdf"`);
+    res.set("Content-Disposition", `attachment; filename="${normalizeFilename(filename)}.pdf"`);
     res.send(pdfBuffer);
-
   } catch (error) {
     console.error("Error generando PDF:", error);
     res.status(500).send("Error al generar el PDF");
-
   } finally {
-    // Siempre cerrar el navegador para liberar memoria
+    if (browser) await browser.close();
+  }
+});
+
+/**
+ * Cloud Function: generarHanziPDF
+ * Recibe: POST { characters: "你好", date?: "...", location?: "..." }
+ * Devuelve: hoja de práctica Hanzi paginada como PDF binario.
+ */
+exports.generarHanziPDF = onRequest({
+  cors: true,
+  memory: "1GiB",
+  timeoutSeconds: 120,
+}, async (req, res) => {
+  if (req.method !== "POST") {
+    return res.status(405).send("Método no permitido");
+  }
+
+  const {
+    characters = "",
+    filename = "hanzi-worksheet",
+    date,
+    location,
+  } = req.body || {};
+  const printableCharacters = getCharactersFromText(characters);
+
+  if (printableCharacters.length === 0) {
+    return res.status(400).send("No hay caracteres Hanzi para generar el PDF");
+  }
+
+  if (printableCharacters.length > MAX_HANZI_PDF_CHARACTERS) {
+    return res.status(400).send(`Máximo ${MAX_HANZI_PDF_CHARACTERS} caracteres por PDF`);
+  }
+
+  let browser = null;
+
+  try {
+    browser = await createBrowser();
+    const page = await browser.newPage();
+    const html = createHanziWorksheetHtml({
+      characters: printableCharacters,
+      date,
+      location,
+    });
+
+    await page.setContent(html, { waitUntil: "networkidle0" });
+    await page.waitForFunction("window.__HANZI_WORKSHEET_READY__ === true", { timeout: 60000 });
+
+    const pdfBuffer = await page.pdf({
+      format: "A4",
+      printBackground: true,
+      preferCSSPageSize: true,
+      margin: {
+        top: "0mm",
+        right: "0mm",
+        bottom: "0mm",
+        left: "0mm",
+      },
+    });
+
+    res.set("Content-Type", "application/pdf");
+    res.set("Cache-Control", "no-store");
+    res.set("Content-Disposition", `attachment; filename="${normalizeFilename(filename)}.pdf"`);
+    res.send(pdfBuffer);
+  } catch (error) {
+    console.error("Error generando PDF Hanzi:", error);
+    res.status(500).send("Error al generar el PDF Hanzi");
+  } finally {
     if (browser) await browser.close();
   }
 });

--- a/functions/index.js
+++ b/functions/index.js
@@ -44,7 +44,7 @@ const createHanziWorksheetHtml = ({ characters, date, location }) => {
       <main class="worksheet-grid">
         ${pageCharacters.map((character, characterIndex) => `
           <div class="hanzi-square" data-char="${escapeHtml(character)}">
-            <div id="hanzi-${pageIndex}-${characterIndex}" class="hanzi-target"></div>
+            <span class="hanzi-glyph">${escapeHtml(character)}</span>
           </div>
         `).join("")}
       </main>
@@ -57,7 +57,9 @@ const createHanziWorksheetHtml = ({ characters, date, location }) => {
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>汉字书写练习</title>
-  <script src="https://cdn.jsdelivr.net/npm/hanzi-writer@2.2.2/dist/hanzi-writer.min.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400&display=swap" rel="stylesheet">
   <style>
     * { box-sizing: border-box; }
     html, body { margin: 0; padding: 0; background: #ffffff; }
@@ -109,10 +111,19 @@ const createHanziWorksheetHtml = ({ characters, date, location }) => {
       background-size: contain;
       background-repeat: no-repeat;
     }
-    .hanzi-target {
-      width: 100%;
-      height: 100%;
-      position: relative;
+    .hanzi-glyph {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #111111;
+      opacity: 0.18;
+      font-family: "Noto Serif SC", "KaiTi", "STKaiti", "Noto Serif CJK SC", "Noto Sans CJK SC", "Microsoft YaHei", "SimSun", serif;
+      font-size: 76px;
+      font-weight: 400;
+      line-height: 1;
+      transform: translateY(-2px);
       z-index: 1;
     }
   </style>
@@ -120,24 +131,7 @@ const createHanziWorksheetHtml = ({ characters, date, location }) => {
 <body>
   ${pageMarkup}
   <script>
-    window.__HANZI_WORKSHEET_READY__ = false;
-    const renderTargets = Array.from(document.querySelectorAll('.hanzi-square'));
-    renderTargets.forEach((square) => {
-      const target = square.querySelector('.hanzi-target');
-      const character = square.dataset.char;
-      HanziWriter.create(target.id, character, {
-        width: 100,
-        height: 100,
-        padding: 5,
-        radicalColor: '#168F16',
-        strokeWidth: 3,
-      });
-    });
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        window.__HANZI_WORKSHEET_READY__ = true;
-      });
-    });
+    window.__HANZI_WORKSHEET_READY__ = true;
   </script>
 </body>
 </html>`;

--- a/functions/index.js
+++ b/functions/index.js
@@ -2,7 +2,7 @@ const { onRequest } = require("firebase-functions/v2/https");
 const puppeteer = require("puppeteer-core");
 const chromium = require("@sparticuz/chromium");
 
-const HANZI_BOXES_PER_PAGE = 108;
+const HANZI_BOXES_PER_PAGE = 48;
 const MAX_HANZI_PDF_CHARACTERS = 720;
 
 const normalizeFilename = (filename = "documento") => filename
@@ -90,15 +90,15 @@ const createHanziWorksheetHtml = ({ characters, date, location }) => {
     .worksheet-location { text-align: right; }
     .worksheet-grid {
       display: grid;
-      grid-template-columns: repeat(9, 16mm);
-      grid-auto-rows: 16mm;
-      gap: 5mm 4mm;
+      grid-template-columns: repeat(6, 100px);
+      grid-auto-rows: 100px;
+      gap: 16px 14px;
       align-content: start;
       justify-content: center;
     }
     .hanzi-square {
-      width: 16mm;
-      height: 16mm;
+      width: 100px;
+      height: 100px;
       position: relative;
       border: 1.1px solid #4f4f4f;
       background: #ffffff;
@@ -126,11 +126,11 @@ const createHanziWorksheetHtml = ({ characters, date, location }) => {
       const target = square.querySelector('.hanzi-target');
       const character = square.dataset.char;
       HanziWriter.create(target.id, character, {
-        width: 60,
-        height: 60,
-        padding: 3,
+        width: 100,
+        height: 100,
+        padding: 5,
         radicalColor: '#168F16',
-        strokeWidth: 1.8,
+        strokeWidth: 3,
       });
     });
     requestAnimationFrame(() => {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "preview": "python3 -m http.server 3000 --directory public",
     "preview:docs": "python3 -m http.server 3000 --directory docs",
-    "emulators:hosting": "npx -y firebase-tools@latest emulators:start --only hosting --host 0.0.0.0 --port 5000",
+    "emulators:hosting": "npx -y firebase-tools@latest emulators:start --only hosting,functions",
     "validate:html": "python3 scripts/validate_static_pages.py"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "asian-languages-static",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Static preview tooling for Asian Languages pages.",
+  "scripts": {
+    "preview": "python3 -m http.server 3000 --directory public",
+    "preview:docs": "python3 -m http.server 3000 --directory docs",
+    "emulators:hosting": "npx -y firebase-tools@latest emulators:start --only hosting --host 0.0.0.0 --port 5000",
+    "validate:html": "python3 scripts/validate_static_pages.py"
+  }
+}

--- a/public/hangul.html
+++ b/public/hangul.html
@@ -6,9 +6,9 @@
   <meta name="description" content="Download free printable handwriting practice worksheets for Korean Hangul characters. Improve your writing skills.">
   <title>Korean Hangul Writing Practice Worksheets | Asian Languages</title>
 
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" 
-        rel="stylesheet" 
-        integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" 
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+        rel="stylesheet"
+        integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
         crossorigin="anonymous">
 
   <link rel="stylesheet" href="css/style.css">
@@ -77,13 +77,14 @@
     </div>
 </footer>
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" 
-          integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" 
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+          integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
           crossorigin="anonymous"></script>
 
   <script>
     document.getElementById('current-year').textContent = new Date().getFullYear();
   </script>
+  <script src="js/pdf-utils.js"></script>
   <script src="js/hangul.js"></script>
 </body>
 </html>

--- a/public/hanzi.html
+++ b/public/hanzi.html
@@ -8,8 +8,8 @@
 
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
         <link rel="stylesheet" href="css/style.css">
-        
-        <script src="https://cdn.jsdelivr.net/npm/hanzi-writer@2.2.2/dist/hanzi-writer.min.js"></script>    
+
+        <script src="https://cdn.jsdelivr.net/npm/hanzi-writer@2.2.2/dist/hanzi-writer.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     </head>
@@ -34,7 +34,7 @@
         </nav>
     </div>
 </header>
-            
+
                     <main class="container my-4">
                         <section class="hanzi-introduction text-center mb-5">
                             <h2 class="display-4">Hanzi 汉字 to learn</h2>
@@ -71,7 +71,7 @@
                                                 </label>
                                                 <input type="text" id="quiz-input" class="form-control form-control-lg" placeholder="e.g., 人口木手">
                                             </div>
-                                            
+
                                             <div class="text-center">
                                                 <button id="start-quiz-btn" class="btn btn-warning btn-lg">Start Quiz</button>
                                             </div>
@@ -97,8 +97,9 @@
                                 </div>
                             </div>
                         </footer>
-            
+
             <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
-            <script src="js/hanzi.js"></script>   
+            <script src="js/pdf-utils.js"></script>
+            <script src="js/hanzi.js"></script>
         </body>
 </html>

--- a/public/japanese.html
+++ b/public/japanese.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Japanese - Asian Languages</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" xintegrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crosso[...]
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <!-- Incluimos tu archivo CSS para estilos personalizados -->
     <link rel="stylesheet" href="css/style.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
@@ -30,7 +30,7 @@
         </nav>
     </div>
 </header>
-                
+
     <main class="container my-4">
         <section class="japanese-introduction text-center mb-5">
             <h2 class="display-4">Japanese 日本語 to learn <span class="idioma-japones"></span></h2>
@@ -48,19 +48,19 @@
             <section class="japanese-writing-section text-center">
                 <h2 class="display-4">Japanese writing worksheet</h2>
                 <div id="japanese-writing-grid" class="japanese-writing-grid d-flex flex-wrap justify-content-center border p-3">
-                
+
                     <div id="placeholder-message" class="text-muted mt-3">Write in Japanese.</div>
                 </div>
-              
+
                 <div class="mt-3">
                     <button id="clear-all" class="btn btn-danger me-2">Clear All</button>
                     <button id="download-pdf" class="btn btn-info">Download PDF</button>
                 </div>
             </section>
-            
+
         </section>
     </main>
-  
+
     <footer class="bg-dark text-white text-center py-3">
         <div class="container">
             <p class="mb-0">&copy; <span id="current-year"></span> All rights reserved, by David.</p>
@@ -72,12 +72,13 @@
             </div>
         </div>
     </footer>
-  
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" xintegrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="an[...]
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <script>
         // Script para actualizar el año en el footer
         document.getElementById('current-year').textContent = new Date().getFullYear();
     </script>
+    <script src="js/pdf-utils.js"></script>
     <script src="js/japanese.js"></script>
 </body>
 </html>

--- a/public/js/hangul.js
+++ b/public/js/hangul.js
@@ -39,7 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     canvas.style.top = '0';
                     canvas.style.left = '0';
                     squareContainer.appendChild(canvas);
-                    
+
                     const charDisplay = document.createElement('div');
                     charDisplay.textContent = char;
                     charDisplay.style.fontSize = '3em';
@@ -49,7 +49,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     charDisplay.style.top = '50%';
                     charDisplay.style.left = '50%';
                     charDisplay.style.transform = 'translate(-50%, -50%)';
-                    charDisplay.style.pointerEvents = 'none'; 
+                    charDisplay.style.pointerEvents = 'none';
                     squareContainer.appendChild(charDisplay);
 
                     phraseContainer.appendChild(squareContainer);
@@ -107,7 +107,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             y: clientY - rect.top
                         };
                     };
-                    
+
                     canvas.addEventListener('mousedown', startDrawing);
                     canvas.addEventListener('mousemove', draw);
                     canvas.addEventListener('mouseup', stopDrawing);
@@ -138,7 +138,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const hangulText = event.target.value;
         generateHangulSquares(hangulText);
     });
-    
+
     clearAllButton.addEventListener('click', () => {
         canvases.forEach(canvas => {
             const ctx = canvas.getContext('2d');
@@ -147,38 +147,26 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     downloadPdfButton.addEventListener('click', async () => {
+        if (canvases.length === 0) {
+            alert('No hay caracteres para descargar. Por favor, escribe algunos en el campo de texto.');
+            return;
+        }
+
+        downloadPdfButton.textContent = 'Generando PDF...';
+        downloadPdfButton.disabled = true;
+
         try {
-            const gridElement = document.getElementById('hangul-writing-grid');
-            if (!gridElement) return;
-
-            const canvas = await html2canvas(gridElement, {
-                backgroundColor: "#ffffff"
+            await window.AsianLanguagesPdf.downloadElementAsPdf({
+                element: document.getElementById('hangul-writing-grid'),
+                filename: 'hangul-worksheet.pdf',
+                title: 'Hangul Worksheet',
             });
-
-            const imgData = canvas.toDataURL("image/png");
-
-            const { jsPDF } = window.jspdf;
-            const pdf = new jsPDF("p", "mm", "a4");
-
-            const pageWidth = pdf.internal.pageSize.getWidth();
-
-            const today = new Date().toLocaleDateString("es-ES");
-            pdf.setFont("helvetica", "bold");
-            pdf.setFontSize(16);
-            pdf.text("Hangul Worksheet", pageWidth / 2, 15, { align: "center" });
-
-            pdf.setFont("helvetica", "normal");
-            pdf.setFontSize(12);
-            pdf.text(`Fecha: ${today}`, pageWidth / 2, 23, { align: "center" });
-
-            const imgWidth = pageWidth - 20;
-            const imgHeight = (canvas.height * imgWidth) / canvas.width;
-            pdf.addImage(imgData, "PNG", 10, 30, imgWidth, imgHeight);
-
-            pdf.save("hangul-worksheet.pdf");
         } catch (error) {
             console.error("Error generando PDF:", error);
-            alert("Hubo un error al generar el PDF.");
+            alert("Hubo un error al generar el PDF. Revisa la consola para más detalles.");
+        } finally {
+            downloadPdfButton.textContent = 'Download PDF';
+            downloadPdfButton.disabled = false;
         }
     });
 

--- a/public/js/hanzi.js
+++ b/public/js/hanzi.js
@@ -12,6 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const radicalColor = '#168F16';
     const customStrokeWidth = 3;
+    const maxPreviewCharacters = 60;
 
     let writers = [];
     let quizWriters = [];
@@ -25,18 +26,28 @@ document.addEventListener('DOMContentLoaded', () => {
         if (characters.length === 0) {
             placeholderMessage.style.display = 'block';
             return;
-        } else {
-            placeholderMessage.style.display = 'none';
         }
 
-        for (const char of characters) {
+        placeholderMessage.style.display = 'none';
+
+        const previewCharacters = Array.from(characters).slice(0, maxPreviewCharacters);
+        const fragment = document.createDocumentFragment();
+
+        if (characters.length > maxPreviewCharacters) {
+            const previewNotice = document.createElement('div');
+            previewNotice.classList.add('alert', 'alert-info', 'w-100', 'text-center');
+            previewNotice.textContent = `Vista previa limitada a ${maxPreviewCharacters} caracteres para evitar que la página se congele. El PDF usará todo el texto.`;
+            fragment.appendChild(previewNotice);
+        }
+
+        previewCharacters.forEach((char, index) => {
             const squareContainer = document.createElement('div');
             squareContainer.classList.add('tian-zi-ge-square', 'border', 'border-secondary', 'm-1');
-            const squareId = `hanzi-square-${char}-${Date.now()}`;
+            const squareId = `hanzi-square-${index}-${char.codePointAt(0)}`;
             squareContainer.id = squareId;
-            tianZiGeGrid.appendChild(squareContainer);
+            fragment.appendChild(squareContainer);
 
-            const writer = HanziWriter.create(squareId, char, {
+            const writer = HanziWriter.create(squareContainer, char, {
                 width: 100,
                 height: 100,
                 padding: 5,
@@ -47,7 +58,9 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             squareContainer.addEventListener('click', () => writer.animateCharacter());
             writers.push(writer);
-        }
+        });
+
+        tianZiGeGrid.appendChild(fragment);
     };
 
     const startQuiz = () => {

--- a/public/js/hanzi.js
+++ b/public/js/hanzi.js
@@ -9,9 +9,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const startQuizBtn = document.getElementById('start-quiz-btn');
     const quizTarget = document.getElementById('quiz-target');
     const quizPlaceholder = document.getElementById('quiz-placeholder');
-    
-    const radicalColor = '#168F16'; 
-    const customStrokeWidth = 3; 
+
+    const radicalColor = '#168F16';
+    const customStrokeWidth = 3;
 
     let writers = [];
     let quizWriters = [];
@@ -97,7 +97,7 @@ document.addEventListener('DOMContentLoaded', () => {
     animateAllButton.addEventListener('click', () => {
         writers.forEach(writer => writer.animateCharacter());
     });
-    
+
     startQuizBtn.addEventListener('click', () => {
       startQuiz();
     });
@@ -107,39 +107,15 @@ document.addEventListener('DOMContentLoaded', () => {
             alert('No hay caracteres para descargar.');
             return;
         }
-        
+
         downloadPdfButton.textContent = 'Generando PDF...';
         downloadPdfButton.disabled = true;
 
         try {
-            const gridContainer = document.getElementById('tian-zi-ge-grid');
-            const canvas = await html2canvas(gridContainer, { scale: 2 });
-            const imgData = canvas.toDataURL('image/png');
-
-            const { jsPDF } = window.jspdf;
-            const pdf = new jsPDF({
-                orientation: 'p',
-                unit: 'mm',
-                format: 'a4'
+            await window.AsianLanguagesPdf.downloadElementAsPdf({
+                element: document.getElementById('tian-zi-ge-grid'),
+                filename: 'hanzi-worksheet.pdf',
             });
-
-            const imgWidth = pdf.internal.pageSize.getWidth() - 20;
-            const pageHeight = pdf.internal.pageSize.getHeight();
-            const imgHeight = (canvas.height * imgWidth) / canvas.width;
-            let heightLeft = imgHeight;
-            let position = 10;
-
-            pdf.addImage(imgData, 'PNG', 10, position, imgWidth, imgHeight);
-            heightLeft -= pageHeight;
-
-            while (heightLeft >= 0) {
-                position = heightLeft - imgHeight;
-                pdf.addPage();
-                pdf.addImage(imgData, 'PNG', 10, position, imgWidth, imgHeight);
-                heightLeft -= pageHeight;
-            }
-
-            pdf.save('hanzi-worksheet.pdf');
         } catch (error) {
             console.error('Error generando el PDF:', error);
             alert('Hubo un error al generar el PDF. Revisa la consola para más detalles.');

--- a/public/js/hanzi.js
+++ b/public/js/hanzi.js
@@ -112,8 +112,8 @@ document.addEventListener('DOMContentLoaded', () => {
         downloadPdfButton.disabled = true;
 
         try {
-            await window.AsianLanguagesPdf.downloadElementAsPdf({
-                element: document.getElementById('tian-zi-ge-grid'),
+            await window.AsianLanguagesPdf.downloadHanziWorksheetPdf({
+                characters: hanziInput.value.replace(/\s/g, ''),
                 filename: 'hanzi-worksheet.pdf',
             });
         } catch (error) {

--- a/public/js/japanese.js
+++ b/public/js/japanese.js
@@ -5,15 +5,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const downloadPdfButton = document.getElementById('download-pdf');
     const placeholderMessage = document.getElementById('placeholder-message');
 
-    const canvases = []; 
+    const canvases = [];
 
     /**
-     * 
-     * @param {string} text 
+     *
+     * @param {string} text
      */
     const generateJapaneseSquares = (text) => {
-        japaneseWritingGrid.innerHTML = ''; 
-        canvases.length = 0; 
+        japaneseWritingGrid.innerHTML = '';
+        canvases.length = 0;
 
         if (text.trim().length === 0) {
             placeholderMessage.style.display = 'block';
@@ -22,7 +22,7 @@ document.addEventListener('DOMContentLoaded', () => {
             placeholderMessage.style.display = 'none';
         }
 
-        
+
         const phrases = text.trim().split(' ');
 
         phrases.forEach((phrase, phraseIndex) => {
@@ -44,7 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     canvas.style.top = '0';
                     canvas.style.left = '0';
                     squareContainer.appendChild(canvas);
-                    
+
                     const charDisplay = document.createElement('div');
                     charDisplay.textContent = char;
                     charDisplay.style.fontSize = '3em';
@@ -54,24 +54,24 @@ document.addEventListener('DOMContentLoaded', () => {
                     charDisplay.style.top = '50%';
                     charDisplay.style.left = '50%';
                     charDisplay.style.transform = 'translate(-50%, -50%)';
-                    charDisplay.style.pointerEvents = 'none'; 
+                    charDisplay.style.pointerEvents = 'none';
                     squareContainer.appendChild(charDisplay);
 
                     phraseContainer.appendChild(squareContainer);
                     canvases.push(canvas);
 
-                    
+
                     squareContainer.addEventListener('click', () => {
                         const ctx = canvas.getContext('2d');
-                        ctx.clearRect(0, 0, canvas.width, canvas.height); 
+                        ctx.clearRect(0, 0, canvas.width, canvas.height);
                         ctx.fillStyle = '#333';
-                        ctx.font = '72px Arial'; 
+                        ctx.font = '72px Arial';
                         ctx.textAlign = 'center';
                         ctx.textBaseline = 'middle';
                         ctx.fillText(char, canvas.width / 2, canvas.height / 2);
                     });
 
-                  
+
                     let isDrawing = false;
                     const ctx = canvas.getContext('2d');
                     ctx.strokeStyle = '#333';
@@ -80,7 +80,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
                     const startDrawing = (e) => {
                         isDrawing = true;
-                        charDisplay.style.color = 'transparent'; 
+                        charDisplay.style.color = 'transparent';
                         const pos = getMousePos(canvas, e);
                         ctx.beginPath();
                         ctx.moveTo(pos.x, pos.y);
@@ -115,7 +115,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             y: clientY - rect.top
                         };
                     };
-                    
+
                     canvas.addEventListener('mousedown', startDrawing);
                     canvas.addEventListener('mousemove', draw);
                     canvas.addEventListener('mouseup', stopDrawing);
@@ -146,8 +146,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const japaneseText = event.target.value;
         generateJapaneseSquares(japaneseText);
     });
-    
-   
+
+
     clearAllButton.addEventListener('click', () => {
         canvases.forEach(canvas => {
             const ctx = canvas.getContext('2d');
@@ -155,7 +155,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
- 
+
     downloadPdfButton.addEventListener('click', async () => {
         if (canvases.length === 0) {
             alert('No hay caracteres para descargar. Por favor, escribe algunos en el campo de texto.');
@@ -166,34 +166,10 @@ document.addEventListener('DOMContentLoaded', () => {
         downloadPdfButton.disabled = true;
 
         try {
-            const gridContainer = document.getElementById('japanese-writing-grid');
-            const canvas = await html2canvas(gridContainer, { scale: 2 });
-            const imgData = canvas.toDataURL('image/png');
-
-            const { jsPDF } = window.jspdf;
-            const pdf = new jsPDF({
-                orientation: 'p',
-                unit: 'mm',
-                format: 'a4'
+            await window.AsianLanguagesPdf.downloadElementAsPdf({
+                element: document.getElementById('japanese-writing-grid'),
+                filename: 'japanese-worksheet.pdf',
             });
-
-            const imgWidth = pdf.internal.pageSize.getWidth() - 20;
-            const pageHeight = pdf.internal.pageSize.getHeight();
-            const imgHeight = (canvas.height * imgWidth) / canvas.width;
-            let heightLeft = imgHeight;
-            let position = 10;
-
-            pdf.addImage(imgData, 'PNG', 10, position, imgWidth, imgHeight);
-            heightLeft -= pageHeight;
-
-            while (heightLeft >= 0) {
-                position = heightLeft - imgHeight;
-                pdf.addPage();
-                pdf.addImage(imgData, 'PNG', 10, position, imgWidth, imgHeight);
-                heightLeft -= pageHeight;
-            }
-
-            pdf.save('japanese-worksheet.pdf');
             alert('PDF generado y descargado correctamente!');
         } catch (error) {
             console.error('Error generating PDF:', error);

--- a/public/js/pdf-utils.js
+++ b/public/js/pdf-utils.js
@@ -131,45 +131,17 @@
     };
 
     const createHanziPracticeBox = (character) => {
-        const box = createElement('div', 'hanzi-practice-box');
+        const box = createElement('div', 'tian-zi-ge-square border border-secondary hanzi-practice-box');
         box.dataset.char = character;
         box.style.width = `${HANZI_BOX_SIZE_PX}px`;
         box.style.height = `${HANZI_BOX_SIZE_PX}px`;
-        box.style.border = '1.2px solid #4f4f4f';
+        box.style.border = '1px solid #6c757d';
         box.style.position = 'relative';
-        box.style.display = 'inline-flex';
-        box.style.alignItems = 'center';
-        box.style.justifyContent = 'center';
-        box.style.background = '#ffffff';
+        box.style.backgroundColor = '#ffffff';
+        box.style.backgroundImage = 'url(\'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><line x1="0" y1="0" x2="100" y2="100" stroke="%23DDD" /><line x1="100" y1="0" x2="0" y2="100" stroke="%23DDD" /><line x1="50" y1="0" x2="50" y2="100" stroke="%23DDD" /><line x1="0" y1="50" x2="100" y2="50" stroke="%23DDD" /></svg>\')';
+        box.style.backgroundSize = 'contain';
+        box.style.backgroundRepeat = 'no-repeat';
         box.style.overflow = 'hidden';
-
-        const diagonalDown = createElement('span', 'hanzi-practice-line');
-        diagonalDown.style.position = 'absolute';
-        diagonalDown.style.inset = '0';
-        diagonalDown.style.background = 'linear-gradient(45deg, transparent calc(50% - 0.45px), #7d7d7d calc(50% - 0.45px), #7d7d7d calc(50% + 0.45px), transparent calc(50% + 0.45px))';
-        diagonalDown.style.opacity = '0.55';
-        diagonalDown.style.zIndex = '2';
-
-        const diagonalUp = createElement('span', 'hanzi-practice-line');
-        diagonalUp.style.position = 'absolute';
-        diagonalUp.style.inset = '0';
-        diagonalUp.style.background = 'linear-gradient(-45deg, transparent calc(50% - 0.45px), #7d7d7d calc(50% - 0.45px), #7d7d7d calc(50% + 0.45px), transparent calc(50% + 0.45px))';
-        diagonalUp.style.opacity = '0.55';
-        diagonalUp.style.zIndex = '2';
-
-        const vertical = createElement('span', 'hanzi-practice-line');
-        vertical.style.position = 'absolute';
-        vertical.style.inset = '0';
-        vertical.style.background = 'linear-gradient(90deg, transparent calc(50% - 0.35px), #8d8d8d calc(50% - 0.35px), #8d8d8d calc(50% + 0.35px), transparent calc(50% + 0.35px))';
-        vertical.style.opacity = '0.35';
-        vertical.style.zIndex = '3';
-
-        const horizontal = createElement('span', 'hanzi-practice-line');
-        horizontal.style.position = 'absolute';
-        horizontal.style.inset = '0';
-        horizontal.style.background = 'linear-gradient(0deg, transparent calc(50% - 0.35px), #8d8d8d calc(50% - 0.35px), #8d8d8d calc(50% + 0.35px), transparent calc(50% + 0.35px))';
-        horizontal.style.opacity = '0.35';
-        horizontal.style.zIndex = '3';
 
         const target = createElement('div', 'hanzi-practice-target');
         target.style.width = '100%';
@@ -177,17 +149,7 @@
         target.style.position = 'relative';
         target.style.zIndex = '1';
 
-        const glyph = createElement('span', 'hanzi-practice-glyph', character);
-        glyph.style.color = 'rgba(43, 43, 43, 0.22)';
-        glyph.style.fontFamily = '"Noto Serif CJK SC", "Noto Serif CJK", "SimSun", "Songti SC", "KaiTi", serif';
-        glyph.style.fontSize = '44px';
-        glyph.style.fontWeight = '400';
-        glyph.style.lineHeight = '1';
-        glyph.style.position = 'absolute';
-        glyph.style.zIndex = '1';
-        glyph.style.transform = 'translateY(-1px)';
-
-        box.append(target, glyph, diagonalDown, diagonalUp, vertical, horizontal);
+        box.appendChild(target);
         return box;
     };
 
@@ -265,23 +227,17 @@
         const boxes = Array.from(element.querySelectorAll('.hanzi-practice-box[data-char]'));
         boxes.forEach((box, index) => {
             const target = box.querySelector('.hanzi-practice-target');
-            const fallbackGlyph = box.querySelector('.hanzi-practice-glyph');
             if (!target) return;
 
             target.id = `pdf-hanzi-${Date.now()}-${index}`;
             target.innerHTML = '';
-            if (fallbackGlyph) fallbackGlyph.style.display = 'none';
 
             window.HanziWriter.create(target, box.dataset.char, {
                 width: HANZI_BOX_SIZE_PX,
                 height: HANZI_BOX_SIZE_PX,
-                padding: 2,
-                showOutline: true,
-                showCharacter: true,
-                strokeColor: '#2b2b2b',
-                radicalColor: '#006b2d',
-                outlineColor: '#9a9a9a',
-                strokeWidth: 2.2,
+                padding: 3,
+                radicalColor: '#168F16',
+                strokeWidth: 1.8,
             });
         });
 

--- a/public/js/pdf-utils.js
+++ b/public/js/pdf-utils.js
@@ -143,13 +143,22 @@
         box.style.backgroundRepeat = 'no-repeat';
         box.style.overflow = 'hidden';
 
-        const target = createElement('div', 'hanzi-practice-target');
-        target.style.width = '100%';
-        target.style.height = '100%';
-        target.style.position = 'relative';
-        target.style.zIndex = '1';
+        const glyph = createElement('span', 'hanzi-practice-glyph', character);
+        glyph.style.position = 'absolute';
+        glyph.style.inset = '0';
+        glyph.style.display = 'flex';
+        glyph.style.alignItems = 'center';
+        glyph.style.justifyContent = 'center';
+        glyph.style.color = '#111111';
+        glyph.style.opacity = '0.18';
+        glyph.style.fontFamily = '"Noto Serif SC", "KaiTi", "STKaiti", "Noto Serif CJK SC", "Noto Sans CJK SC", "Microsoft YaHei", "SimSun", serif';
+        glyph.style.fontSize = '76px';
+        glyph.style.fontWeight = '400';
+        glyph.style.lineHeight = '1';
+        glyph.style.transform = 'translateY(-2px)';
+        glyph.style.zIndex = '1';
 
-        box.appendChild(target);
+        box.appendChild(glyph);
         return box;
     };
 
@@ -217,32 +226,19 @@
         return worksheet;
     };
 
-    const waitForAnimationFrames = () => new Promise((resolve) => {
+    const ensureHanziGuideFont = () => {
+        if (document.querySelector('link[data-asian-languages-hanzi-font]')) return;
+
+        const fontLink = document.createElement('link');
+        fontLink.dataset.asianLanguagesHanziFont = 'true';
+        fontLink.rel = 'stylesheet';
+        fontLink.href = 'https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400&display=swap';
+        document.head.appendChild(fontLink);
+    };
+
+    const waitForPdfLayout = () => new Promise((resolve) => {
         requestAnimationFrame(() => requestAnimationFrame(resolve));
     });
-
-    const renderHanziWritersInWorksheet = async (element) => {
-        if (!window.HanziWriter) return;
-
-        const boxes = Array.from(element.querySelectorAll('.hanzi-practice-box[data-char]'));
-        boxes.forEach((box, index) => {
-            const target = box.querySelector('.hanzi-practice-target');
-            if (!target) return;
-
-            target.id = `pdf-hanzi-${Date.now()}-${index}`;
-            target.innerHTML = '';
-
-            window.HanziWriter.create(target, box.dataset.char, {
-                width: HANZI_BOX_SIZE_PX,
-                height: HANZI_BOX_SIZE_PX,
-                padding: 5,
-                radicalColor: '#168F16',
-                strokeWidth: 3,
-            });
-        });
-
-        await waitForAnimationFrames();
-    };
 
     const withHiddenPrintableElement = async (element, callback) => {
         const host = createElement('div', 'pdf-render-host');
@@ -302,7 +298,8 @@
             });
 
             await withHiddenPrintableElement(worksheet, async (element) => {
-                await renderHanziWritersInWorksheet(element);
+                ensureHanziGuideFont();
+                await waitForPdfLayout();
                 const canvas = await renderElementToCanvas(element);
                 const imgData = canvas.toDataURL('image/png');
                 if (pageIndex > 0) pdf.addPage();

--- a/public/js/pdf-utils.js
+++ b/public/js/pdf-utils.js
@@ -96,9 +96,11 @@
     };
 
 
-    const HANZI_BOX_SIZE_PX = 58;
+    const HANZI_BOX_SIZE_PX = 60;
     const HANZI_PAGE_WIDTH_PX = 794;
     const HANZI_PAGE_MIN_HEIGHT_PX = 1123;
+    const HANZI_BOXES_PER_PAGE = 108;
+    const MAX_HANZI_PDF_CHARACTERS = 720;
 
     const isHanziPracticeCharacter = (character) => /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(character);
 
@@ -109,37 +111,87 @@
         return element;
     };
 
+    const chunkCharacters = (characters, size) => {
+        const chunks = [];
+        for (let index = 0; index < characters.length; index += size) {
+            chunks.push(characters.slice(index, index + size));
+        }
+        return chunks;
+    };
+
+    const downloadBlob = (blob, filename) => {
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        URL.revokeObjectURL(url);
+    };
+
     const createHanziPracticeBox = (character) => {
         const box = createElement('div', 'hanzi-practice-box');
+        box.dataset.char = character;
         box.style.width = `${HANZI_BOX_SIZE_PX}px`;
         box.style.height = `${HANZI_BOX_SIZE_PX}px`;
-        box.style.border = '1.5px solid #8a8a8a';
+        box.style.border = '1.2px solid #4f4f4f';
         box.style.position = 'relative';
         box.style.display = 'inline-flex';
         box.style.alignItems = 'center';
         box.style.justifyContent = 'center';
-        box.style.background = [
-            'linear-gradient(45deg, transparent calc(50% - 0.5px), #d5d5d5 calc(50% - 0.5px), #d5d5d5 calc(50% + 0.5px), transparent calc(50% + 0.5px))',
-            'linear-gradient(-45deg, transparent calc(50% - 0.5px), #d5d5d5 calc(50% - 0.5px), #d5d5d5 calc(50% + 0.5px), transparent calc(50% + 0.5px))',
-            'linear-gradient(90deg, transparent calc(50% - 0.5px), #eeeeee calc(50% - 0.5px), #eeeeee calc(50% + 0.5px), transparent calc(50% + 0.5px))',
-            'linear-gradient(0deg, transparent calc(50% - 0.5px), #eeeeee calc(50% - 0.5px), #eeeeee calc(50% + 0.5px), transparent calc(50% + 0.5px))',
-            '#ffffff',
-        ].join(', ');
+        box.style.background = '#ffffff';
+        box.style.overflow = 'hidden';
+
+        const diagonalDown = createElement('span', 'hanzi-practice-line');
+        diagonalDown.style.position = 'absolute';
+        diagonalDown.style.inset = '0';
+        diagonalDown.style.background = 'linear-gradient(45deg, transparent calc(50% - 0.45px), #7d7d7d calc(50% - 0.45px), #7d7d7d calc(50% + 0.45px), transparent calc(50% + 0.45px))';
+        diagonalDown.style.opacity = '0.55';
+        diagonalDown.style.zIndex = '2';
+
+        const diagonalUp = createElement('span', 'hanzi-practice-line');
+        diagonalUp.style.position = 'absolute';
+        diagonalUp.style.inset = '0';
+        diagonalUp.style.background = 'linear-gradient(-45deg, transparent calc(50% - 0.45px), #7d7d7d calc(50% - 0.45px), #7d7d7d calc(50% + 0.45px), transparent calc(50% + 0.45px))';
+        diagonalUp.style.opacity = '0.55';
+        diagonalUp.style.zIndex = '2';
+
+        const vertical = createElement('span', 'hanzi-practice-line');
+        vertical.style.position = 'absolute';
+        vertical.style.inset = '0';
+        vertical.style.background = 'linear-gradient(90deg, transparent calc(50% - 0.35px), #8d8d8d calc(50% - 0.35px), #8d8d8d calc(50% + 0.35px), transparent calc(50% + 0.35px))';
+        vertical.style.opacity = '0.35';
+        vertical.style.zIndex = '3';
+
+        const horizontal = createElement('span', 'hanzi-practice-line');
+        horizontal.style.position = 'absolute';
+        horizontal.style.inset = '0';
+        horizontal.style.background = 'linear-gradient(0deg, transparent calc(50% - 0.35px), #8d8d8d calc(50% - 0.35px), #8d8d8d calc(50% + 0.35px), transparent calc(50% + 0.35px))';
+        horizontal.style.opacity = '0.35';
+        horizontal.style.zIndex = '3';
+
+        const target = createElement('div', 'hanzi-practice-target');
+        target.style.width = '100%';
+        target.style.height = '100%';
+        target.style.position = 'relative';
+        target.style.zIndex = '1';
 
         const glyph = createElement('span', 'hanzi-practice-glyph', character);
-        glyph.style.color = 'rgba(0, 0, 0, 0.16)';
+        glyph.style.color = 'rgba(43, 43, 43, 0.22)';
         glyph.style.fontFamily = '"Noto Serif CJK SC", "Noto Serif CJK", "SimSun", "Songti SC", "KaiTi", serif';
-        glyph.style.fontSize = '42px';
+        glyph.style.fontSize = '44px';
         glyph.style.fontWeight = '400';
         glyph.style.lineHeight = '1';
+        glyph.style.position = 'absolute';
+        glyph.style.zIndex = '1';
         glyph.style.transform = 'translateY(-1px)';
-        box.appendChild(glyph);
 
+        box.append(target, glyph, diagonalDown, diagonalUp, vertical, horizontal);
         return box;
     };
 
-    const createHanziWorksheetTemplate = ({ characters, date, location }) => {
-        const printableCharacters = Array.from(characters).filter((character) => character.trim().length > 0);
+    const createHanziWorksheetPage = ({ characters, date, location }) => {
         const worksheet = createElement('section', 'hanzi-printable-worksheet');
         worksheet.setAttribute('aria-hidden', 'true');
         worksheet.style.width = `${HANZI_PAGE_WIDTH_PX}px`;
@@ -148,16 +200,16 @@
         worksheet.style.color = '#111111';
         worksheet.style.fontFamily = 'Arial, "Microsoft YaHei", "PingFang SC", sans-serif';
         worksheet.style.boxSizing = 'border-box';
-        worksheet.style.padding = '0 48px 48px';
+        worksheet.style.padding = '0 52px 52px';
 
         const header = createElement('header', 'hanzi-worksheet-header');
-        header.style.height = '72px';
+        header.style.height = '84px';
         header.style.display = 'grid';
         header.style.gridTemplateColumns = '1fr auto 1fr';
         header.style.alignItems = 'center';
         header.style.borderBottom = '2px solid #ff2f55';
-        header.style.margin = '0 -48px 26px';
-        header.style.padding = '0 48px';
+        header.style.margin = '0 -52px 30px';
+        header.style.padding = '0 52px';
         header.style.boxSizing = 'border-box';
         header.style.background = '#f7f7f7';
 
@@ -178,14 +230,14 @@
         worksheet.appendChild(header);
 
         const grid = createElement('div', 'hanzi-worksheet-grid');
-        grid.style.display = 'flex';
-        grid.style.flexWrap = 'wrap';
-        grid.style.alignItems = 'center';
-        grid.style.alignContent = 'flex-start';
-        grid.style.columnGap = '14px';
-        grid.style.rowGap = '18px';
+        grid.style.display = 'grid';
+        grid.style.gridTemplateColumns = `repeat(9, ${HANZI_BOX_SIZE_PX}px)`;
+        grid.style.gridAutoRows = `${HANZI_BOX_SIZE_PX}px`;
+        grid.style.gap = '18px 14px';
+        grid.style.alignContent = 'start';
+        grid.style.justifyContent = 'center';
 
-        printableCharacters.forEach((character) => {
+        characters.forEach((character) => {
             if (isHanziPracticeCharacter(character)) {
                 grid.appendChild(createHanziPracticeBox(character));
                 return;
@@ -201,6 +253,39 @@
 
         worksheet.appendChild(grid);
         return worksheet;
+    };
+
+    const waitForAnimationFrames = () => new Promise((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(resolve));
+    });
+
+    const renderHanziWritersInWorksheet = async (element) => {
+        if (!window.HanziWriter) return;
+
+        const boxes = Array.from(element.querySelectorAll('.hanzi-practice-box[data-char]'));
+        boxes.forEach((box, index) => {
+            const target = box.querySelector('.hanzi-practice-target');
+            const fallbackGlyph = box.querySelector('.hanzi-practice-glyph');
+            if (!target) return;
+
+            target.id = `pdf-hanzi-${Date.now()}-${index}`;
+            target.innerHTML = '';
+            if (fallbackGlyph) fallbackGlyph.style.display = 'none';
+
+            window.HanziWriter.create(target, box.dataset.char, {
+                width: HANZI_BOX_SIZE_PX,
+                height: HANZI_BOX_SIZE_PX,
+                padding: 2,
+                showOutline: true,
+                showCharacter: true,
+                strokeColor: '#2b2b2b',
+                radicalColor: '#006b2d',
+                outlineColor: '#9a9a9a',
+                strokeWidth: 2.2,
+            });
+        });
+
+        await waitForAnimationFrames();
     };
 
     const withHiddenPrintableElement = async (element, callback) => {
@@ -220,24 +305,89 @@
         }
     };
 
+    const tryDownloadHanziWorksheetFromFirebase = async ({ characters, filename, date, location }) => {
+        const response = await fetch('/generarHanziPDF', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                characters,
+                filename: filename.replace(/\.pdf$/i, ''),
+                date,
+                location,
+            }),
+        });
+
+        const contentType = response.headers.get('content-type') || '';
+        if (!response.ok || !contentType.includes('application/pdf')) {
+            const errorMessage = await response.text().catch(() => 'No se pudo generar el PDF en Firebase.');
+            throw new Error(errorMessage || 'No se pudo generar el PDF en Firebase.');
+        }
+
+        const pdfBlob = await response.blob();
+        downloadBlob(pdfBlob, filename);
+    };
+
+    const downloadHanziWorksheetLocally = async ({ characters, filename, date, location }) => {
+        const pages = chunkCharacters(characters, HANZI_BOXES_PER_PAGE);
+        const { jsPDF } = window.jspdf;
+        const pdf = new jsPDF({
+            orientation: 'p',
+            unit: 'mm',
+            format: 'a4',
+        });
+
+        for (let pageIndex = 0; pageIndex < pages.length; pageIndex += 1) {
+            const worksheet = createHanziWorksheetPage({
+                characters: pages[pageIndex],
+                date,
+                location,
+            });
+
+            await withHiddenPrintableElement(worksheet, async (element) => {
+                await renderHanziWritersInWorksheet(element);
+                const canvas = await renderElementToCanvas(element);
+                const imgData = canvas.toDataURL('image/png');
+                if (pageIndex > 0) pdf.addPage();
+                pdf.addImage(imgData, 'PNG', 0, 0, 210, 297);
+            });
+        }
+
+        pdf.save(filename);
+    };
+
     const downloadHanziWorksheetPdf = async ({ characters, filename = 'hanzi-worksheet.pdf', date, location }) => {
-        if (!characters || Array.from(characters.replace(/\s/g, '')).length === 0) {
+        ensurePdfDependencies();
+
+        const printableCharacters = Array.from((characters || '').replace(/\s/g, ''));
+        if (printableCharacters.length === 0) {
             throw new Error('No hay caracteres Hanzi para generar el PDF.');
         }
 
-        const formattedDate = date || new Date().toLocaleDateString('es-ES');
-        const worksheet = createHanziWorksheetTemplate({
-            characters,
-            date: formattedDate,
-            location,
-        });
+        if (printableCharacters.length > MAX_HANZI_PDF_CHARACTERS) {
+            throw new Error(`Por ahora el PDF permite máximo ${MAX_HANZI_PDF_CHARACTERS} caracteres para evitar archivos demasiado pesados.`);
+        }
 
-        await withHiddenPrintableElement(worksheet, async (element) => {
-            await downloadElementAsPdf({
-                element,
+        const formattedDate = date || new Date().toLocaleDateString('es-ES');
+        const charactersText = printableCharacters.join('');
+
+        try {
+            await tryDownloadHanziWorksheetFromFirebase({
+                characters: charactersText,
                 filename,
+                date: formattedDate,
+                location,
             });
-        });
+        } catch (firebaseError) {
+            console.warn('Firebase PDF generation unavailable; using browser fallback.', firebaseError);
+            await downloadHanziWorksheetLocally({
+                characters: printableCharacters,
+                filename,
+                date: formattedDate,
+                location,
+            });
+        }
     };
 
     window.AsianLanguagesPdf = {

--- a/public/js/pdf-utils.js
+++ b/public/js/pdf-utils.js
@@ -1,0 +1,101 @@
+(function (window) {
+    const DEFAULT_MARGIN_MM = 10;
+
+    const ensurePdfDependencies = () => {
+        if (typeof window.html2canvas !== 'function') {
+            throw new Error('html2canvas no está cargado. Revisa la conexión al CDN antes de descargar el PDF.');
+        }
+
+        if (!window.jspdf || typeof window.jspdf.jsPDF !== 'function') {
+            throw new Error('jsPDF no está cargado. Revisa la conexión al CDN antes de descargar el PDF.');
+        }
+    };
+
+    const waitForFonts = async () => {
+        if (document.fonts && typeof document.fonts.ready?.then === 'function') {
+            await document.fonts.ready;
+        }
+    };
+
+    const renderElementToCanvas = async (element) => {
+        if (!element) {
+            throw new Error('No se encontró el elemento que se debe convertir a PDF.');
+        }
+
+        await waitForFonts();
+
+        const scale = Math.max(2, Math.ceil(window.devicePixelRatio || 1));
+        const canvas = await window.html2canvas(element, {
+            backgroundColor: '#ffffff',
+            logging: false,
+            scale,
+            useCORS: true,
+            windowWidth: document.documentElement.scrollWidth,
+        });
+
+        if (!canvas.width || !canvas.height) {
+            throw new Error('No se pudo capturar contenido visible para el PDF.');
+        }
+
+        return canvas;
+    };
+
+    const addCanvasToPdfPages = (pdf, canvas, margin = DEFAULT_MARGIN_MM) => {
+        const imgData = canvas.toDataURL('image/png');
+        const pageWidth = pdf.internal.pageSize.getWidth();
+        const pageHeight = pdf.internal.pageSize.getHeight();
+        const printableWidth = pageWidth - (margin * 2);
+        const printableHeight = pageHeight - (margin * 2);
+        const imgHeight = (canvas.height * printableWidth) / canvas.width;
+
+        let renderedHeight = 0;
+
+        pdf.addImage(imgData, 'PNG', margin, margin, printableWidth, imgHeight);
+        renderedHeight += printableHeight;
+
+        while (renderedHeight < imgHeight) {
+            pdf.addPage();
+            pdf.addImage(
+                imgData,
+                'PNG',
+                margin,
+                margin - renderedHeight,
+                printableWidth,
+                imgHeight
+            );
+            renderedHeight += printableHeight;
+        }
+    };
+
+    const downloadElementAsPdf = async ({ element, filename, title }) => {
+        ensurePdfDependencies();
+
+        const canvas = await renderElementToCanvas(element);
+        const { jsPDF } = window.jspdf;
+        const pdf = new jsPDF({
+            orientation: 'p',
+            unit: 'mm',
+            format: 'a4',
+        });
+
+        if (title) {
+            const pageWidth = pdf.internal.pageSize.getWidth();
+            const today = new Date().toLocaleDateString('es-ES');
+            pdf.setFont('helvetica', 'bold');
+            pdf.setFontSize(16);
+            pdf.text(title, pageWidth / 2, 14, { align: 'center' });
+            pdf.setFont('helvetica', 'normal');
+            pdf.setFontSize(11);
+            pdf.text(`Fecha: ${today}`, pageWidth / 2, 21, { align: 'center' });
+            addCanvasToPdfPages(pdf, canvas, 28);
+        } else {
+            addCanvasToPdfPages(pdf, canvas);
+        }
+
+        pdf.save(filename);
+    };
+
+    window.AsianLanguagesPdf = {
+        downloadElementAsPdf,
+    };
+})(window);

--- a/public/js/pdf-utils.js
+++ b/public/js/pdf-utils.js
@@ -96,10 +96,10 @@
     };
 
 
-    const HANZI_BOX_SIZE_PX = 60;
+    const HANZI_BOX_SIZE_PX = 100;
     const HANZI_PAGE_WIDTH_PX = 794;
     const HANZI_PAGE_MIN_HEIGHT_PX = 1123;
-    const HANZI_BOXES_PER_PAGE = 108;
+    const HANZI_BOXES_PER_PAGE = 48;
     const MAX_HANZI_PDF_CHARACTERS = 720;
 
     const isHanziPracticeCharacter = (character) => /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(character);
@@ -193,9 +193,9 @@
 
         const grid = createElement('div', 'hanzi-worksheet-grid');
         grid.style.display = 'grid';
-        grid.style.gridTemplateColumns = `repeat(9, ${HANZI_BOX_SIZE_PX}px)`;
+        grid.style.gridTemplateColumns = `repeat(6, ${HANZI_BOX_SIZE_PX}px)`;
         grid.style.gridAutoRows = `${HANZI_BOX_SIZE_PX}px`;
-        grid.style.gap = '18px 14px';
+        grid.style.gap = '16px 14px';
         grid.style.alignContent = 'start';
         grid.style.justifyContent = 'center';
 
@@ -235,9 +235,9 @@
             window.HanziWriter.create(target, box.dataset.char, {
                 width: HANZI_BOX_SIZE_PX,
                 height: HANZI_BOX_SIZE_PX,
-                padding: 3,
+                padding: 5,
                 radicalColor: '#168F16',
-                strokeWidth: 1.8,
+                strokeWidth: 3,
             });
         });
 

--- a/public/js/pdf-utils.js
+++ b/public/js/pdf-utils.js
@@ -95,7 +95,153 @@
         pdf.save(filename);
     };
 
+
+    const HANZI_BOX_SIZE_PX = 58;
+    const HANZI_PAGE_WIDTH_PX = 794;
+    const HANZI_PAGE_MIN_HEIGHT_PX = 1123;
+
+    const isHanziPracticeCharacter = (character) => /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(character);
+
+    const createElement = (tagName, className, textContent) => {
+        const element = document.createElement(tagName);
+        if (className) element.className = className;
+        if (textContent) element.textContent = textContent;
+        return element;
+    };
+
+    const createHanziPracticeBox = (character) => {
+        const box = createElement('div', 'hanzi-practice-box');
+        box.style.width = `${HANZI_BOX_SIZE_PX}px`;
+        box.style.height = `${HANZI_BOX_SIZE_PX}px`;
+        box.style.border = '1.5px solid #8a8a8a';
+        box.style.position = 'relative';
+        box.style.display = 'inline-flex';
+        box.style.alignItems = 'center';
+        box.style.justifyContent = 'center';
+        box.style.background = [
+            'linear-gradient(45deg, transparent calc(50% - 0.5px), #d5d5d5 calc(50% - 0.5px), #d5d5d5 calc(50% + 0.5px), transparent calc(50% + 0.5px))',
+            'linear-gradient(-45deg, transparent calc(50% - 0.5px), #d5d5d5 calc(50% - 0.5px), #d5d5d5 calc(50% + 0.5px), transparent calc(50% + 0.5px))',
+            'linear-gradient(90deg, transparent calc(50% - 0.5px), #eeeeee calc(50% - 0.5px), #eeeeee calc(50% + 0.5px), transparent calc(50% + 0.5px))',
+            'linear-gradient(0deg, transparent calc(50% - 0.5px), #eeeeee calc(50% - 0.5px), #eeeeee calc(50% + 0.5px), transparent calc(50% + 0.5px))',
+            '#ffffff',
+        ].join(', ');
+
+        const glyph = createElement('span', 'hanzi-practice-glyph', character);
+        glyph.style.color = 'rgba(0, 0, 0, 0.16)';
+        glyph.style.fontFamily = '"Noto Serif CJK SC", "Noto Serif CJK", "SimSun", "Songti SC", "KaiTi", serif';
+        glyph.style.fontSize = '42px';
+        glyph.style.fontWeight = '400';
+        glyph.style.lineHeight = '1';
+        glyph.style.transform = 'translateY(-1px)';
+        box.appendChild(glyph);
+
+        return box;
+    };
+
+    const createHanziWorksheetTemplate = ({ characters, date, location }) => {
+        const printableCharacters = Array.from(characters).filter((character) => character.trim().length > 0);
+        const worksheet = createElement('section', 'hanzi-printable-worksheet');
+        worksheet.setAttribute('aria-hidden', 'true');
+        worksheet.style.width = `${HANZI_PAGE_WIDTH_PX}px`;
+        worksheet.style.minHeight = `${HANZI_PAGE_MIN_HEIGHT_PX}px`;
+        worksheet.style.background = '#ffffff';
+        worksheet.style.color = '#111111';
+        worksheet.style.fontFamily = 'Arial, "Microsoft YaHei", "PingFang SC", sans-serif';
+        worksheet.style.boxSizing = 'border-box';
+        worksheet.style.padding = '0 48px 48px';
+
+        const header = createElement('header', 'hanzi-worksheet-header');
+        header.style.height = '72px';
+        header.style.display = 'grid';
+        header.style.gridTemplateColumns = '1fr auto 1fr';
+        header.style.alignItems = 'center';
+        header.style.borderBottom = '2px solid #ff2f55';
+        header.style.margin = '0 -48px 26px';
+        header.style.padding = '0 48px';
+        header.style.boxSizing = 'border-box';
+        header.style.background = '#f7f7f7';
+
+        const dateLabel = createElement('div', 'hanzi-worksheet-meta', `日期: ${date || '__________'}`);
+        dateLabel.style.fontSize = '17px';
+        dateLabel.style.fontWeight = '700';
+        const title = createElement('h1', 'hanzi-worksheet-title', '汉字书写练习');
+        title.style.margin = '0';
+        title.style.fontSize = '28px';
+        title.style.fontWeight = '800';
+        title.style.letterSpacing = '2px';
+        const locationLabel = createElement('div', 'hanzi-worksheet-meta', `地点: ${location || '__________'}`);
+        locationLabel.style.fontSize = '17px';
+        locationLabel.style.fontWeight = '700';
+        locationLabel.style.textAlign = 'right';
+
+        header.append(dateLabel, title, locationLabel);
+        worksheet.appendChild(header);
+
+        const grid = createElement('div', 'hanzi-worksheet-grid');
+        grid.style.display = 'flex';
+        grid.style.flexWrap = 'wrap';
+        grid.style.alignItems = 'center';
+        grid.style.alignContent = 'flex-start';
+        grid.style.columnGap = '14px';
+        grid.style.rowGap = '18px';
+
+        printableCharacters.forEach((character) => {
+            if (isHanziPracticeCharacter(character)) {
+                grid.appendChild(createHanziPracticeBox(character));
+                return;
+            }
+
+            const punctuation = createElement('span', 'hanzi-worksheet-punctuation', character);
+            punctuation.style.color = 'rgba(0, 0, 0, 0.28)';
+            punctuation.style.fontSize = '32px';
+            punctuation.style.minWidth = '18px';
+            punctuation.style.textAlign = 'center';
+            grid.appendChild(punctuation);
+        });
+
+        worksheet.appendChild(grid);
+        return worksheet;
+    };
+
+    const withHiddenPrintableElement = async (element, callback) => {
+        const host = createElement('div', 'pdf-render-host');
+        host.style.position = 'fixed';
+        host.style.left = '-10000px';
+        host.style.top = '0';
+        host.style.zIndex = '-1';
+        host.style.background = '#ffffff';
+        host.appendChild(element);
+        document.body.appendChild(host);
+
+        try {
+            return await callback(element);
+        } finally {
+            host.remove();
+        }
+    };
+
+    const downloadHanziWorksheetPdf = async ({ characters, filename = 'hanzi-worksheet.pdf', date, location }) => {
+        if (!characters || Array.from(characters.replace(/\s/g, '')).length === 0) {
+            throw new Error('No hay caracteres Hanzi para generar el PDF.');
+        }
+
+        const formattedDate = date || new Date().toLocaleDateString('es-ES');
+        const worksheet = createHanziWorksheetTemplate({
+            characters,
+            date: formattedDate,
+            location,
+        });
+
+        await withHiddenPrintableElement(worksheet, async (element) => {
+            await downloadElementAsPdf({
+                element,
+                filename,
+            });
+        });
+    };
+
     window.AsianLanguagesPdf = {
         downloadElementAsPdf,
+        downloadHanziWorksheetPdf,
     };
 })(window);

--- a/readme.md
+++ b/readme.md
@@ -117,7 +117,7 @@ If you want to test the Firebase Hosting layout without deploying production, ru
 npm run emulators:hosting
 ```
 
-Then open the forwarded port `5000` in Codespaces. The hosting emulator serves the `public/` folder configured in `firebase.json`.
+Then open the forwarded port `5000` in Codespaces. The hosting emulator serves the `public/` folder configured in `firebase.json` and rewrites Hanzi PDF requests to the Firebase Function, so long PDF generation can run in the emulator instead of blocking the browser.
 
 ### Static validation
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# 你好! 안녕! やあ! 
+# 你好! 안녕! やあ!
 # 👋 Welcome to the Language Learning Project!
 
 This is an educational and interactive web application designed to help you practice writing characters from different languages. It offers a dynamic way to learn stroke order and sentence formatting, all within a modern and responsive interface. **Specifically, for Hanzi, Kanji, and Hangul, the application will display the stroke order for each character within dedicated input boxes, guiding you through the correct writing sequence.**
@@ -89,3 +89,42 @@ This project is licensed under the MIT License. See the `LICENSE` file for more 
 ---
 
 © 2025 David Gerena. All rights reserved.
+
+---
+
+## 🧪 Preview branch for PDF download testing
+
+This branch is intended to test worksheet PDF downloads without publishing to `asian-languages.com`.
+
+### GitHub Codespaces / online port preview
+
+1. Open the repository in GitHub Codespaces.
+2. Run:
+   ```bash
+   npm run preview
+   ```
+3. Codespaces will forward port `3000`. Open the forwarded URL and test:
+   * `/hanzi.html`
+   * `/hangul.html`
+   * `/japanese.html`
+4. Type sample characters and click **Download PDF**. The download is generated in the browser, so it does not require deploying the production domain.
+
+### Firebase Hosting emulator preview
+
+If you want to test the Firebase Hosting layout without deploying production, run:
+
+```bash
+npm run emulators:hosting
+```
+
+Then open the forwarded port `5000` in Codespaces. The hosting emulator serves the `public/` folder configured in `firebase.json`.
+
+### Static validation
+
+Run this check before testing manually:
+
+```bash
+npm run validate:html
+```
+
+It verifies that Hanzi, Hangul, and Japanese pages load `html2canvas`, `jsPDF`, and the shared PDF helper before each page script.

--- a/scripts/validate_static_pages.py
+++ b/scripts/validate_static_pages.py
@@ -1,0 +1,77 @@
+from html.parser import HTMLParser
+from pathlib import Path
+import sys
+
+PAGES = [
+    Path("public/hanzi.html"),
+    Path("public/hangul.html"),
+    Path("public/japanese.html"),
+    Path("docs/hanzi.html"),
+    Path("docs/hangul.html"),
+    Path("docs/japanese.html"),
+]
+REQUIRED_SCRIPTS = {
+    "https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js",
+    "https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js",
+    "js/pdf-utils.js",
+}
+
+class ScriptParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.scripts = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag != "script":
+            return
+        attrs = dict(attrs)
+        if "src" in attrs:
+            self.scripts.append(attrs["src"])
+
+
+def validate_page(path: Path) -> list[str]:
+    parser = ScriptParser()
+    parser.feed(path.read_text(encoding="utf-8"))
+    errors = []
+    missing = REQUIRED_SCRIPTS.difference(parser.scripts)
+    if missing:
+        errors.append(f"{path}: missing scripts: {', '.join(sorted(missing))}")
+
+    page_script = f"js/{path.stem}.js"
+    if page_script not in parser.scripts:
+        errors.append(f"{path}: missing page script {page_script}")
+    elif "js/pdf-utils.js" in parser.scripts:
+        if parser.scripts.index("js/pdf-utils.js") > parser.scripts.index(page_script):
+            errors.append(f"{path}: js/pdf-utils.js must load before {page_script}")
+
+    return errors
+
+
+def main() -> int:
+    errors = []
+    for page in PAGES:
+        errors.extend(validate_page(page))
+
+    for js_path in [
+        Path("public/js/hanzi.js"),
+        Path("public/js/hangul.js"),
+        Path("public/js/japanese.js"),
+        Path("docs/js/hanzi.js"),
+        Path("docs/js/hangul.js"),
+        Path("docs/js/japanese.js"),
+    ]:
+        contents = js_path.read_text(encoding="utf-8")
+        if "AsianLanguagesPdf.downloadElementAsPdf" not in contents:
+            errors.append(f"{js_path}: does not use shared PDF downloader")
+
+    if errors:
+        print("Static validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("Static validation passed.")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_static_pages.py
+++ b/scripts/validate_static_pages.py
@@ -61,7 +61,14 @@ def main() -> int:
         Path("docs/js/japanese.js"),
     ]:
         contents = js_path.read_text(encoding="utf-8")
-        if "AsianLanguagesPdf.downloadElementAsPdf" not in contents:
+        uses_pdf_helper = any(
+            helper_name in contents
+            for helper_name in [
+                "AsianLanguagesPdf.downloadElementAsPdf",
+                "AsianLanguagesPdf.downloadHanziWorksheetPdf",
+            ]
+        )
+        if not uses_pdf_helper:
             errors.append(f"{js_path}: does not use shared PDF downloader")
 
     if errors:


### PR DESCRIPTION
### Motivation
- Permitir probar la descarga de PDFs sin tocar el dominio de producción alojando una vista previa local/online y centralizar la lógica de generación para mayor robustez.
- Evitar dependencias de un backend de producción para descargas rápidas en entornos de prueba y Codespaces.

### Description
- Añadido helper compartido `public/js/pdf-utils.js` (y su copia en `docs/js/`) que valida dependencias (`html2canvas`, `jsPDF`), espera fuentes, renderiza el elemento a canvas y divide el contenido largo en páginas A4 antes de guardar el PDF.
- Reescrito los controladores de descarga en `public/js/hanzi.js`, `public/js/hangul.js` y `public/js/japanese.js` (y sus copias en `docs/js/`) para usar el helper `AsianLanguagesPdf.downloadElementAsPdf` y manejar estado de carga/errores y nombres de archivo consistentes.
- Preparado un flujo de previsualización para Codespaces/puertos con `package.json` scripts (`npm run preview`, `npm run preview:docs`, `npm run emulators:hosting`) y añadido `.devcontainer/devcontainer.json` para abrir puertos `3000`/`5000`.
- Ajustado `firebase.json` para servir la carpeta `public` en emuladores, añadido `scripts/validate_static_pages.py` para validar que las páginas carguen `html2canvas`, `jsPDF` y `js/pdf-utils.js` antes del script de página, y documentado el proceso en `readme.md`.

### Testing
- Ejecutado la validación estática con `npm run validate:html` y el script devolvió éxito (`Static validation passed.`).
- Comprobado sintaxis estática de JS con `node --check` sobre los scripts relevantes y no se reportaron errores.
- Arrancada una vista previa estática con `python3 -m http.server --directory public` y verificados los endpoints `/hanzi.html`, `/hangul.html` y `/japanese.html` mediante peticiones HEAD, las páginas respondieron correctamente (HTTP 200).
- Nota: la instalación/ejecución de Playwright falló por un `403 Forbidden` desde el registro npm, por lo que no se pudieron ejecutar tests E2E headless en este entorno; todos los checks estáticos y la verificación de servidor local sí pasaron.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0481d89950832ab8b7a24273f572ef)